### PR TITLE
Implement back navigation for map screen

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/MainActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/MainActivity.kt
@@ -48,8 +48,10 @@ class MainActivity : AppCompatActivity() {
                 }
                 R.id.nav_map -> {
                     toolbar.title = getString(R.string.title_map)
-                    toolbar.navigationIcon = null
-                    toolbar.setNavigationOnClickListener(null)
+                    toolbar.navigationIcon = ContextCompat.getDrawable(this, R.drawable.ic_arrow_back_black_24)
+                    toolbar.setNavigationOnClickListener {
+                        bottomNav.selectedItemId = R.id.nav_home
+                    }
                     supportFragmentManager.commit {
                         replace(R.id.fragment_container, MapFragment())
                     }

--- a/app/src/main/java/com/pnu/pnuguide/ui/map/MapActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/map/MapActivity.kt
@@ -16,6 +16,7 @@ import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.MarkerOptions
 import com.google.android.material.appbar.MaterialToolbar
 import com.pnu.pnuguide.R
+import com.pnu.pnuguide.MainActivity
 
 class MapActivity : AppCompatActivity(), OnMapReadyCallback {
 
@@ -27,7 +28,12 @@ class MapActivity : AppCompatActivity(), OnMapReadyCallback {
 
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_map)
         setSupportActionBar(toolbar)
-        toolbar.setNavigationOnClickListener { finish() }
+        toolbar.setNavigationOnClickListener {
+            val intent = Intent(this, MainActivity::class.java)
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            startActivity(intent)
+            finish()
+        }
 
         val mapFragment = supportFragmentManager
             .findFragmentById(R.id.map_fragment) as SupportMapFragment


### PR DESCRIPTION
## Summary
- show back arrow while map is selected in bottom nav
- pressing the back arrow on the map screen returns to Home
- pressing the back arrow in `MapActivity` also brings the user back to `MainActivity`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685562f3887483328ececc06533f711a