### PR TITLE
Implement basic map directions flow

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,7 @@
         <activity android:name=".MainActivity" />
         <activity android:name="com.pnu.pnuguide.ui.home.HomeActivity" />
         <activity android:name="com.pnu.pnuguide.ui.map.MapActivity" />
+        <activity android:name="com.pnu.pnuguide.ui.map.DirectionsActivity" />
         <activity android:name="com.pnu.pnuguide.ui.profile.ProfileActivity" />
         <activity android:name="com.pnu.pnuguide.ui.course.CourseActivity" />
         <activity android:name="com.pnu.pnuguide.ui.stamp.StampActivity" />

--- a/app/src/main/java/com/pnu/pnuguide/ui/map/DirectionsActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/map/DirectionsActivity.kt
@@ -1,0 +1,75 @@
+package com.pnu.pnuguide.ui.map
+
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Bundle
+import android.widget.EditText
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.button.MaterialButton
+import com.pnu.pnuguide.R
+
+class DirectionsActivity : AppCompatActivity() {
+
+    private lateinit var editStart: EditText
+    private lateinit var editDestination: EditText
+
+    private var destLat: Double = Double.NaN
+    private var destLng: Double = Double.NaN
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_directions)
+
+        val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_directions)
+        setSupportActionBar(toolbar)
+        toolbar.setNavigationOnClickListener { finish() }
+
+        editStart = findViewById(R.id.edit_start)
+        editDestination = findViewById(R.id.edit_destination)
+
+        val destName = intent.getStringExtra(EXTRA_DEST_NAME) ?: ""
+        destLat = intent.getDoubleExtra(EXTRA_DEST_LATITUDE, Double.NaN)
+        destLng = intent.getDoubleExtra(EXTRA_DEST_LONGITUDE, Double.NaN)
+
+        editStart.setText(getString(R.string.my_location))
+        editDestination.setText(destName)
+
+        findViewById<MaterialButton>(R.id.button_open_maps).setOnClickListener {
+            openGoogleMaps()
+        }
+
+        requestLocationPermission()
+    }
+
+    private fun requestLocationPermission() {
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            ActivityCompat.requestPermissions(
+                this,
+                arrayOf(Manifest.permission.ACCESS_FINE_LOCATION),
+                LOCATION_PERMISSION_REQUEST
+            )
+        }
+    }
+
+    private fun openGoogleMaps() {
+        if (destLat.isNaN() || destLng.isNaN()) return
+        val gmmIntentUri = Uri.parse("google.navigation:q=$destLat,$destLng")
+        val intent = Intent(Intent.ACTION_VIEW, gmmIntentUri)
+        intent.setPackage("com.google.android.apps.maps")
+        startActivity(intent)
+    }
+
+    companion object {
+        const val EXTRA_DEST_NAME = "extra_dest_name"
+        const val EXTRA_DEST_LATITUDE = "extra_dest_latitude"
+        const val EXTRA_DEST_LONGITUDE = "extra_dest_longitude"
+        private const val LOCATION_PERMISSION_REQUEST = 2
+    }
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/map/MapActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/map/MapActivity.kt
@@ -64,9 +64,11 @@ class MapActivity : AppCompatActivity(), OnMapReadyCallback {
         googleMap.addMarker(MarkerOptions().position(pnu).title("PNU"))
         enableMyLocation()
         googleMap.setOnInfoWindowClickListener { marker ->
-            val gmmIntentUri = Uri.parse("google.navigation:q=${marker.position.latitude},${marker.position.longitude}")
-            val intent = Intent(Intent.ACTION_VIEW, gmmIntentUri)
-            intent.setPackage("com.google.android.apps.maps")
+            val intent = Intent(this, DirectionsActivity::class.java).apply {
+                putExtra(DirectionsActivity.EXTRA_DEST_NAME, marker.title)
+                putExtra(DirectionsActivity.EXTRA_DEST_LATITUDE, marker.position.latitude)
+                putExtra(DirectionsActivity.EXTRA_DEST_LONGITUDE, marker.position.longitude)
+            }
             startActivity(intent)
         }
     }

--- a/app/src/main/res/layout/activity_directions.xml
+++ b/app/src/main/res/layout/activity_directions.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar_directions"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        android:navigationIcon="@drawable/ic_arrow_back_black_24"
+        android:title="@string/get_directions" />
+
+    <EditText
+        android:id="@+id/edit_start"
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        android:background="@color/divider"
+        android:hint="@string/start_point"
+        android:padding="12dp"
+        android:layout_marginTop="16dp"
+        android:textColor="@color/text_primary"
+        android:textColorHint="@color/text_secondary" />
+
+    <EditText
+        android:id="@+id/edit_destination"
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        android:background="@color/divider"
+        android:hint="@string/destination"
+        android:padding="12dp"
+        android:layout_marginTop="8dp"
+        android:textColor="@color/text_primary"
+        android:textColorHint="@color/text_secondary" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_open_maps"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/open_in_google_maps" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,10 @@
     <string name="watch_video">Watch Video</string>
     <string name="collect_stamp">Collect Stamp</string>
     <string name="get_directions">길 찾기</string>
+    <string name="start_point">출발지</string>
+    <string name="destination">도착지</string>
+    <string name="open_in_google_maps">Google Maps로 이동</string>
+    <string name="my_location">현재 위치</string>
     <string name="get_started">Get Started</string>
     <string name="log_in">Log in</string>
     <string name="sign_up">Sign up</string>


### PR DESCRIPTION
## Summary
- add a new `DirectionsActivity` for selecting start and destination
- allow launching Google Maps navigation from that screen
- hook up map marker InfoWindow to open the new directions UI
- add UI layout and string resources for the directions screen
- register the new activity in the manifest

## Testing
- `./gradlew tasks --all`
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68558ab340448332baeba840b70e3972