### PR TITLE
Add chatbot fragment with bottom nav

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -99,6 +99,7 @@ dependencies {
     implementation("androidx.navigation:navigation-fragment-ktx:2.7.7")
     implementation("androidx.navigation:navigation-ui-ktx:2.7.7")
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.9.0")
+    implementation("androidx.recyclerview:recyclerview:1.3.2")
 
     // Firebase
     implementation(platform("com.google.firebase:firebase-bom:33.1.0"))

--- a/app/src/main/java/com/pnu/pnuguide/MainActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/MainActivity.kt
@@ -12,6 +12,7 @@ import com.pnu.pnuguide.ui.map.MapFragment
 import com.pnu.pnuguide.ui.map.MapActivity
 import androidx.core.content.ContextCompat
 import com.pnu.pnuguide.ui.profile.ProfileFragment
+import com.pnu.pnuguide.ui.chat.ChatFragment
 
 class MainActivity : AppCompatActivity() {
 
@@ -66,6 +67,18 @@ class MainActivity : AppCompatActivity() {
                     toolbar.setNavigationOnClickListener(null)
                     supportFragmentManager.commit {
                         replace(R.id.fragment_container, ProfileFragment())
+                    }
+                    true
+                }
+                R.id.nav_chat -> {
+                    toolbar.title = getString(R.string.title_chatbot)
+                    supportActionBar?.setDisplayHomeAsUpEnabled(false)
+                    toolbar.setNavigationIcon(R.drawable.ic_map)
+                    toolbar.setNavigationOnClickListener {
+                        startActivity(Intent(this, MapActivity::class.java))
+                    }
+                    supportFragmentManager.commit {
+                        replace(R.id.fragment_container, ChatFragment())
                     }
                     true
                 }

--- a/app/src/main/java/com/pnu/pnuguide/ui/ChatActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/ChatActivity.kt
@@ -8,7 +8,7 @@ import com.pnu.pnuguide.R
 class ChatActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.fragment_chat)
+        setContentView(R.layout.activity_chat)
 
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_chat)
         setSupportActionBar(toolbar)

--- a/app/src/main/java/com/pnu/pnuguide/ui/ChatFragment.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/ChatFragment.kt
@@ -4,14 +4,20 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
+import android.widget.EditText
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.pnu.pnuguide.R
+import kotlinx.coroutines.flow.collectLatest
 
 class ChatFragment : Fragment() {
 
     private val viewModel by viewModels<ChatViewModel>()
+    private lateinit var adapter: ChatAdapter
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -23,6 +29,22 @@ class ChatFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        // TODO: setup RecyclerView and send button
+        adapter = ChatAdapter()
+        val recycler = view.findViewById<RecyclerView>(R.id.recycler_chat)
+        recycler.layoutManager = LinearLayoutManager(requireContext())
+        recycler.adapter = adapter
+
+        val edit = view.findViewById<EditText>(R.id.edit_message)
+        view.findViewById<Button>(R.id.button_send).setOnClickListener {
+            val text = edit.text.toString().trim()
+            if (text.isNotEmpty()) {
+                viewModel.sendMessage(text)
+                edit.setText("")
+            }
+        }
+
+        viewLifecycleOwner.lifecycleScope.launchWhenStarted {
+            viewModel.messages.collectLatest { adapter.submitList(it) }
+        }
     }
 }

--- a/app/src/main/java/com/pnu/pnuguide/ui/HomeFragment.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/HomeFragment.kt
@@ -8,7 +8,6 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import com.google.android.material.button.MaterialButton
 import com.pnu.pnuguide.R
-import com.pnu.pnuguide.ui.chat.ChatActivity
 import com.pnu.pnuguide.ui.course.CourseActivity
 import com.pnu.pnuguide.ui.stamp.StampActivity
 
@@ -28,9 +27,6 @@ class HomeFragment : Fragment() {
         }
         view.findViewById<MaterialButton>(R.id.btn_stamp).setOnClickListener {
             startActivity(Intent(requireContext(), StampActivity::class.java))
-        }
-        view.findViewById<MaterialButton>(R.id.btn_chat).setOnClickListener {
-            startActivity(Intent(requireContext(), ChatActivity::class.java))
         }
     }
 }

--- a/app/src/main/java/com/pnu/pnuguide/ui/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/chat/ChatAdapter.kt
@@ -1,0 +1,41 @@
+package com.pnu.pnuguide.ui.chat
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.pnu.pnuguide.R
+
+class ChatAdapter : RecyclerView.Adapter<ChatAdapter.MessageViewHolder>() {
+    private val items = mutableListOf<ChatUiMessage>()
+
+    fun submitList(list: List<ChatUiMessage>) {
+        items.clear()
+        items.addAll(list)
+        notifyDataSetChanged()
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return if (items[position].isUser) 1 else 0
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MessageViewHolder {
+        val layoutId = if (viewType == 1) R.layout.item_message_user else R.layout.item_message_bot
+        val view = LayoutInflater.from(parent.context).inflate(layoutId, parent, false)
+        return MessageViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: MessageViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    inner class MessageViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val messageText: TextView = itemView.findViewById(R.id.text_message)
+        fun bind(item: ChatUiMessage) {
+            messageText.text = item.content
+        }
+    }
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/chat/ChatUiMessage.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/chat/ChatUiMessage.kt
@@ -1,0 +1,3 @@
+package com.pnu.pnuguide.ui.chat
+
+data class ChatUiMessage(val content: String, val isUser: Boolean)

--- a/app/src/main/res/drawable/bg_message_bot.xml
+++ b/app/src/main/res/drawable/bg_message_bot.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/divider"/>
+    <corners android:radius="12dp"/>
+</shape>

--- a/app/src/main/res/drawable/bg_message_user.xml
+++ b/app/src/main/res/drawable/bg_message_user.xml
@@ -1,0 +1,4 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/primary"/>
+    <corners android:radius="12dp"/>
+</shape>

--- a/app/src/main/res/drawable/ic_chatbot.xml
+++ b/app/src/main/res/drawable/ic_chatbot.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp" android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#FF000000"
+        android:pathData="M20 2H4c-1.1 0-2 .9-2 2v16l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2z"/>
+</vector>

--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar_chat"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/background_light"
+        android:navigationIcon="@drawable/ic_arrow_back_black_24"
+        android:title="@string/title_chatbot"
+        android:titleTextColor="@color/text_primary"
+        app:titleCentered="true" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_chat"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <EditText
+        android:id="@+id/edit_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Type here" />
+
+    <Button
+        android:id="@+id/button_send"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Send" />
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_chat.xml
+++ b/app/src/main/res/layout/fragment_chat.xml
@@ -1,20 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:padding="16dp">
-
-    <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/toolbar_chat"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@color/background_light"
-        android:navigationIcon="@drawable/ic_arrow_back_black_24"
-        android:title="@string/title_chatbot"
-        android:titleTextColor="@color/text_primary"
-        app:titleCentered="true" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_chat"
@@ -22,15 +11,22 @@
         android:layout_height="0dp"
         android:layout_weight="1" />
 
-    <EditText
-        android:id="@+id/edit_message"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="Type here" />
+        android:orientation="horizontal">
 
-    <Button
-        android:id="@+id/button_send"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Send" />
+        <EditText
+            android:id="@+id/edit_message"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="Type here" />
+
+        <Button
+            android:id="@+id/button_send"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Send" />
+    </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -32,16 +32,6 @@
             app:backgroundTint="@color/primary"
             app:cornerRadius="8dp" />
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/btn_chat"
-            android:layout_width="match_parent"
-            android:layout_height="48dp"
-            android:layout_marginBottom="12dp"
-            android:text="Chatbot"
-            android:textStyle="bold"
-            android:textColor="@android:color/white"
-            app:backgroundTint="@color/primary"
-            app:cornerRadius="8dp" />
 
         <androidx.cardview.widget.CardView
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/item_message_bot.xml
+++ b/app/src/main/res/layout/item_message_bot.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="start">
+
+    <TextView
+        android:id="@+id/text_message"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/bg_message_bot"
+        android:padding="8dp"
+        android:textColor="@color/text_primary" />
+</LinearLayout>

--- a/app/src/main/res/layout/item_message_user.xml
+++ b/app/src/main/res/layout/item_message_user.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="end">
+
+    <TextView
+        android:id="@+id/text_message"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:background="@drawable/bg_message_user"
+        android:padding="8dp"
+        android:textColor="@android:color/white" />
+</LinearLayout>

--- a/app/src/main/res/menu/menu_bottom_nav.xml
+++ b/app/src/main/res/menu/menu_bottom_nav.xml
@@ -12,4 +12,8 @@
         android:id="@+id/nav_profile"
         android:icon="@drawable/ic_profile"
         android:title="@string/title_profile" />
+    <item
+        android:id="@+id/nav_chat"
+        android:icon="@drawable/ic_chatbot"
+        android:title="@string/title_chatbot" />
 </menu>


### PR DESCRIPTION
## Summary
- add drawable and layout resources for chatbot messages
- implement ChatAdapter, ChatUiMessage, ChatViewModel
- create ChatFragment UI without its own toolbar
- hook chatbot screen to bottom navigation and remove old button
- adjust existing ChatActivity to use dedicated layout
- add RecyclerView dependency

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559ba0b96083329392d679eb6b937d