### PR TITLE
Add settings gear across toolbars

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/ui/ChatActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/ChatActivity.kt
@@ -1,9 +1,11 @@
 package com.pnu.pnuguide.ui.chat
 
 import android.os.Bundle
+import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.appbar.MaterialToolbar
 import com.pnu.pnuguide.R
+import com.pnu.pnuguide.ui.SettingsActivity
 
 class ChatActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -13,5 +15,13 @@ class ChatActivity : AppCompatActivity() {
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_chat)
         setSupportActionBar(toolbar)
         toolbar.setNavigationOnClickListener { finish() }
+        toolbar.setOnMenuItemClickListener { item ->
+            if (item.itemId == R.id.action_settings) {
+                startActivity(Intent(this, SettingsActivity::class.java))
+                true
+            } else {
+                false
+            }
+        }
     }
 }

--- a/app/src/main/java/com/pnu/pnuguide/ui/CourseActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/CourseActivity.kt
@@ -1,9 +1,11 @@
 package com.pnu.pnuguide.ui.course
 
 import android.os.Bundle
+import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.appbar.MaterialToolbar
 import com.pnu.pnuguide.R
+import com.pnu.pnuguide.ui.SettingsActivity
 
 class CourseActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -13,5 +15,13 @@ class CourseActivity : AppCompatActivity() {
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_course)
         setSupportActionBar(toolbar)
         toolbar.setNavigationOnClickListener { finish() }
+        toolbar.setOnMenuItemClickListener { item ->
+            if (item.itemId == R.id.action_settings) {
+                startActivity(Intent(this, SettingsActivity::class.java))
+                true
+            } else {
+                false
+            }
+        }
     }
 }

--- a/app/src/main/java/com/pnu/pnuguide/ui/StampActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/StampActivity.kt
@@ -1,9 +1,11 @@
 package com.pnu.pnuguide.ui.stamp
 
 import android.os.Bundle
+import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.appbar.MaterialToolbar
 import com.pnu.pnuguide.R
+import com.pnu.pnuguide.ui.SettingsActivity
 
 class StampActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -13,5 +15,13 @@ class StampActivity : AppCompatActivity() {
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_stamp)
         setSupportActionBar(toolbar)
         toolbar.setNavigationOnClickListener { finish() }
+        toolbar.setOnMenuItemClickListener { item ->
+            if (item.itemId == R.id.action_settings) {
+                startActivity(Intent(this, SettingsActivity::class.java))
+                true
+            } else {
+                false
+            }
+        }
     }
 }

--- a/app/src/main/java/com/pnu/pnuguide/ui/course/SpotDetailActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/course/SpotDetailActivity.kt
@@ -7,6 +7,7 @@ import android.widget.ImageView
 import android.widget.TextView
 import android.content.Intent
 import android.net.Uri
+import com.pnu.pnuguide.ui.SettingsActivity
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.button.MaterialButton
 import com.pnu.pnuguide.R
@@ -22,6 +23,14 @@ class SpotDetailActivity : AppCompatActivity() {
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_spot_detail)
         setSupportActionBar(toolbar)
         toolbar.setNavigationOnClickListener { finish() }
+        toolbar.setOnMenuItemClickListener { item ->
+            if (item.itemId == R.id.action_settings) {
+                startActivity(Intent(this, SettingsActivity::class.java))
+                true
+            } else {
+                false
+            }
+        }
 
         val title = intent.getStringExtra(EXTRA_TITLE) ?: ""
         val desc = intent.getStringExtra(EXTRA_DESCRIPTION) ?: ""

--- a/app/src/main/java/com/pnu/pnuguide/ui/course/SpotListActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/course/SpotListActivity.kt
@@ -1,10 +1,12 @@
 package com.pnu.pnuguide.ui.course
 
 import android.os.Bundle
+import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.MaterialToolbar
 import com.pnu.pnuguide.R
+import com.pnu.pnuguide.ui.SettingsActivity
 
 class SpotListActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -14,6 +16,14 @@ class SpotListActivity : AppCompatActivity() {
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_spot_list)
         setSupportActionBar(toolbar)
         toolbar.setNavigationOnClickListener { finish() }
+        toolbar.setOnMenuItemClickListener { item ->
+            if (item.itemId == R.id.action_settings) {
+                startActivity(Intent(this, SettingsActivity::class.java))
+                true
+            } else {
+                false
+            }
+        }
 
         // TODO: load spot list
     }

--- a/app/src/main/java/com/pnu/pnuguide/ui/map/DirectionsActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/map/DirectionsActivity.kt
@@ -12,6 +12,7 @@ import androidx.core.content.ContextCompat
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.button.MaterialButton
 import com.pnu.pnuguide.R
+import com.pnu.pnuguide.ui.SettingsActivity
 
 class DirectionsActivity : AppCompatActivity() {
 
@@ -28,6 +29,14 @@ class DirectionsActivity : AppCompatActivity() {
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_directions)
         setSupportActionBar(toolbar)
         toolbar.setNavigationOnClickListener { finish() }
+        toolbar.setOnMenuItemClickListener { item ->
+            if (item.itemId == R.id.action_settings) {
+                startActivity(Intent(this, SettingsActivity::class.java))
+                true
+            } else {
+                false
+            }
+        }
 
         editStart = findViewById(R.id.edit_start)
         editDestination = findViewById(R.id.edit_destination)

--- a/app/src/main/java/com/pnu/pnuguide/ui/map/MapActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/map/MapActivity.kt
@@ -23,6 +23,7 @@ import com.google.android.gms.maps.model.MarkerOptions
 import com.google.android.material.appbar.MaterialToolbar
 import com.pnu.pnuguide.R
 import com.pnu.pnuguide.MainActivity
+import com.pnu.pnuguide.ui.SettingsActivity
 
 class MapActivity : AppCompatActivity(), OnMapReadyCallback {
 
@@ -43,6 +44,14 @@ class MapActivity : AppCompatActivity(), OnMapReadyCallback {
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
             startActivity(intent)
             finish()
+        }
+        toolbar.setOnMenuItemClickListener { item ->
+            if (item.itemId == R.id.action_settings) {
+                startActivity(Intent(this, SettingsActivity::class.java))
+                true
+            } else {
+                false
+            }
         }
 
         val mapFragment = supportFragmentManager

--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -14,7 +14,8 @@
         android:navigationIcon="@drawable/ic_arrow_back_black_24"
         android:title="@string/title_chatbot"
         android:titleTextColor="@color/text_primary"
-        app:titleCentered="true" />
+        app:titleCentered="true"
+        app:menu="@menu/menu_home_toolbar" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_chat"

--- a/app/src/main/res/layout/activity_directions.xml
+++ b/app/src/main/res/layout/activity_directions.xml
@@ -12,7 +12,8 @@
         android:layout_height="wrap_content"
         android:background="?attr/colorPrimary"
         android:navigationIcon="@drawable/ic_arrow_back_black_24"
-        android:title="@string/get_directions" />
+        android:title="@string/get_directions"
+        app:menu="@menu/menu_home_toolbar" />
 
     <EditText
         android:id="@+id/edit_start"

--- a/app/src/main/res/layout/activity_map.xml
+++ b/app/src/main/res/layout/activity_map.xml
@@ -11,7 +11,8 @@
         android:layout_height="wrap_content"
         android:background="?attr/colorPrimary"
         android:navigationIcon="@drawable/ic_arrow_back_black_24"
-        android:title="@string/title_map" />
+        android:title="@string/title_map"
+        app:menu="@menu/menu_home_toolbar" />
 
     <androidx.appcompat.widget.SearchView
         android:id="@+id/search_view_map"

--- a/app/src/main/res/layout/activity_spot_detail.xml
+++ b/app/src/main/res/layout/activity_spot_detail.xml
@@ -12,7 +12,8 @@
         android:layout_height="wrap_content"
         android:background="?attr/colorPrimary"
         android:navigationIcon="@drawable/ic_arrow_back_black_24"
-        android:title="@string/app_name" />
+        android:title="@string/app_name"
+        app:menu="@menu/menu_home_toolbar" />
 
     <ImageView
         android:id="@+id/image_spot"

--- a/app/src/main/res/layout/activity_spot_list.xml
+++ b/app/src/main/res/layout/activity_spot_list.xml
@@ -11,7 +11,8 @@
         android:layout_height="wrap_content"
         android:background="?attr/colorPrimary"
         android:navigationIcon="@drawable/ic_arrow_back_black_24"
-        android:title="@string/app_name" />
+        android:title="@string/app_name"
+        app:menu="@menu/menu_home_toolbar" />
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recycler_spots"

--- a/app/src/main/res/layout/fragment_course.xml
+++ b/app/src/main/res/layout/fragment_course.xml
@@ -13,7 +13,8 @@
         android:navigationIcon="@drawable/ic_arrow_back_black_24"
         android:title="@string/title_course"
         android:titleTextColor="@color/text_primary"
-        app:titleCentered="true" />
+        app:titleCentered="true"
+        app:menu="@menu/menu_home_toolbar" />
 
     <TextView
         android:id="@+id/text_course"

--- a/app/src/main/res/layout/fragment_stamp.xml
+++ b/app/src/main/res/layout/fragment_stamp.xml
@@ -13,7 +13,8 @@
         android:navigationIcon="@drawable/ic_arrow_back_black_24"
         android:title="@string/title_stamp"
         android:titleTextColor="@color/text_primary"
-        app:titleCentered="true" />
+        app:titleCentered="true"
+        app:menu="@menu/menu_home_toolbar" />
 
     <TextView
         android:id="@+id/text_stamp"


### PR DESCRIPTION
## Summary
- show Settings gear menu on toolbars in all activities
- handle gear clicks to open `SettingsActivity`
- keep Settings screen with back arrow only

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855a1dff5408332aca940f4652b219a