### PR TITLE
Add toolbar to HomeActivity

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/ui/HomeActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/HomeActivity.kt
@@ -1,12 +1,31 @@
 package com.pnu.pnuguide.ui.home
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.appbar.MaterialToolbar
 import com.pnu.pnuguide.R
+import com.pnu.pnuguide.ui.SettingsActivity
+import com.pnu.pnuguide.ui.map.MapActivity
 
 class HomeActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.fragment_home)
+        setContentView(R.layout.activity_home)
+
+        val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_home)
+        setSupportActionBar(toolbar)
+        toolbar.inflateMenu(R.menu.menu_home_toolbar)
+        toolbar.setNavigationOnClickListener {
+            startActivity(Intent(this, MapActivity::class.java))
+        }
+        toolbar.setOnMenuItemClickListener { item ->
+            if (item.itemId == R.id.action_settings) {
+                startActivity(Intent(this, SettingsActivity::class.java))
+                true
+            } else {
+                false
+            }
+        }
     }
 }

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar_home"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/background_light"
+        android:navigationIcon="@drawable/ic_map"
+        android:title="@string/title_home"
+        android:titleTextColor="@color/text_primary"
+        app:titleCentered="true" />
+
+    <fragment
+        android:id="@+id/fragment_home"
+        android:name="com.pnu.pnuguide.ui.home.HomeFragment"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add MaterialToolbar to HomeActivity layout
- open map from navigation icon and settings from gear icon

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ab4048348332ad22b937c4403b22