### PR TITLE
Unify header setup with helper functions

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/ui/ChatActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/ChatActivity.kt
@@ -1,11 +1,10 @@
 package com.pnu.pnuguide.ui.chat
 
 import android.os.Bundle
-import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.appbar.MaterialToolbar
 import com.pnu.pnuguide.R
-import com.pnu.pnuguide.ui.SettingsActivity
+import com.pnu.pnuguide.ui.HeaderUtils.setupHeader1
 
 class ChatActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -13,16 +12,6 @@ class ChatActivity : AppCompatActivity() {
         setContentView(R.layout.activity_chat)
 
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_chat)
-        setSupportActionBar(toolbar)
-        toolbar.inflateMenu(R.menu.menu_home_toolbar)
-        toolbar.setNavigationOnClickListener { finish() }
-        toolbar.setOnMenuItemClickListener { item ->
-            if (item.itemId == R.id.action_settings) {
-                startActivity(Intent(this, SettingsActivity::class.java))
-                true
-            } else {
-                false
-            }
-        }
+        toolbar.setupHeader1(this, R.string.title_chatbot)
     }
 }

--- a/app/src/main/java/com/pnu/pnuguide/ui/CourseActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/CourseActivity.kt
@@ -1,11 +1,10 @@
 package com.pnu.pnuguide.ui.course
 
 import android.os.Bundle
-import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.appbar.MaterialToolbar
 import com.pnu.pnuguide.R
-import com.pnu.pnuguide.ui.SettingsActivity
+import com.pnu.pnuguide.ui.HeaderUtils.setupHeader1
 
 class CourseActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -13,16 +12,6 @@ class CourseActivity : AppCompatActivity() {
         setContentView(R.layout.fragment_course)
 
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_course)
-        setSupportActionBar(toolbar)
-        toolbar.inflateMenu(R.menu.menu_home_toolbar)
-        toolbar.setNavigationOnClickListener { finish() }
-        toolbar.setOnMenuItemClickListener { item ->
-            if (item.itemId == R.id.action_settings) {
-                startActivity(Intent(this, SettingsActivity::class.java))
-                true
-            } else {
-                false
-            }
-        }
+        toolbar.setupHeader1(this, R.string.title_course)
     }
 }

--- a/app/src/main/java/com/pnu/pnuguide/ui/HeaderUtils.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/HeaderUtils.kt
@@ -1,0 +1,33 @@
+package com.pnu.pnuguide.ui
+
+import android.content.Intent
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.appbar.MaterialToolbar
+import androidx.core.content.ContextCompat
+import com.pnu.pnuguide.R
+import com.pnu.pnuguide.ui.map.MapActivity
+
+fun MaterialToolbar.setupHeader1(activity: AppCompatActivity, titleResId: Int) {
+    activity.setSupportActionBar(this)
+    this.title = activity.getString(titleResId)
+    this.navigationIcon = ContextCompat.getDrawable(activity, R.drawable.ic_map)
+    this.setNavigationOnClickListener {
+        activity.startActivity(Intent(activity, MapActivity::class.java))
+    }
+    this.inflateMenu(R.menu.menu_home_toolbar)
+    this.setOnMenuItemClickListener { item ->
+        if (item.itemId == R.id.action_settings) {
+            activity.startActivity(Intent(activity, SettingsActivity::class.java))
+            true
+        } else {
+            false
+        }
+    }
+}
+
+fun MaterialToolbar.setupHeader2(activity: AppCompatActivity, titleResId: Int) {
+    activity.setSupportActionBar(this)
+    this.title = activity.getString(titleResId)
+    this.navigationIcon = ContextCompat.getDrawable(activity, R.drawable.ic_arrow_back_black_24)
+    this.setNavigationOnClickListener { activity.finish() }
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/HomeActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/HomeActivity.kt
@@ -1,12 +1,10 @@
 package com.pnu.pnuguide.ui.home
 
-import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.appbar.MaterialToolbar
 import com.pnu.pnuguide.R
-import com.pnu.pnuguide.ui.SettingsActivity
-import com.pnu.pnuguide.ui.map.MapActivity
+import com.pnu.pnuguide.ui.HeaderUtils.setupHeader1
 
 class HomeActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -14,18 +12,6 @@ class HomeActivity : AppCompatActivity() {
         setContentView(R.layout.activity_home)
 
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_home)
-        setSupportActionBar(toolbar)
-        toolbar.inflateMenu(R.menu.menu_home_toolbar)
-        toolbar.setNavigationOnClickListener {
-            startActivity(Intent(this, MapActivity::class.java))
-        }
-        toolbar.setOnMenuItemClickListener { item ->
-            if (item.itemId == R.id.action_settings) {
-                startActivity(Intent(this, SettingsActivity::class.java))
-                true
-            } else {
-                false
-            }
-        }
+        toolbar.setupHeader1(this, R.string.title_home)
     }
 }

--- a/app/src/main/java/com/pnu/pnuguide/ui/SettingsActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/SettingsActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.appbar.MaterialToolbar
 import com.pnu.pnuguide.R
+import com.pnu.pnuguide.ui.HeaderUtils.setupHeader2
 import android.widget.TextView
 import android.widget.ImageView
 
@@ -13,8 +14,7 @@ class SettingsActivity : AppCompatActivity() {
         setContentView(R.layout.activity_settings)
 
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_settings)
-        setSupportActionBar(toolbar)
-        toolbar.setNavigationOnClickListener { finish() }
+        toolbar.setupHeader2(this, R.string.settings)
 
         setItem(R.id.item_account, R.drawable.ic_arrow_back_black_24, "Account Settings")
         setItem(R.id.item_notification, R.drawable.ic_arrow_back_black_24, "Notification Settings")

--- a/app/src/main/java/com/pnu/pnuguide/ui/StampActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/StampActivity.kt
@@ -1,11 +1,10 @@
 package com.pnu.pnuguide.ui.stamp
 
 import android.os.Bundle
-import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.appbar.MaterialToolbar
 import com.pnu.pnuguide.R
-import com.pnu.pnuguide.ui.SettingsActivity
+import com.pnu.pnuguide.ui.HeaderUtils.setupHeader1
 
 class StampActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -13,16 +12,6 @@ class StampActivity : AppCompatActivity() {
         setContentView(R.layout.fragment_stamp)
 
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_stamp)
-        setSupportActionBar(toolbar)
-        toolbar.inflateMenu(R.menu.menu_home_toolbar)
-        toolbar.setNavigationOnClickListener { finish() }
-        toolbar.setOnMenuItemClickListener { item ->
-            if (item.itemId == R.id.action_settings) {
-                startActivity(Intent(this, SettingsActivity::class.java))
-                true
-            } else {
-                false
-            }
-        }
+        toolbar.setupHeader1(this, R.string.title_stamp)
     }
 }

--- a/app/src/main/java/com/pnu/pnuguide/ui/course/SpotDetailActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/course/SpotDetailActivity.kt
@@ -7,7 +7,7 @@ import android.widget.ImageView
 import android.widget.TextView
 import android.content.Intent
 import android.net.Uri
-import com.pnu.pnuguide.ui.SettingsActivity
+import com.pnu.pnuguide.ui.HeaderUtils.setupHeader2
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.button.MaterialButton
 import com.pnu.pnuguide.R
@@ -21,17 +21,8 @@ class SpotDetailActivity : AppCompatActivity() {
         setContentView(R.layout.activity_spot_detail)
 
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_spot_detail)
-        setSupportActionBar(toolbar)
-        toolbar.inflateMenu(R.menu.menu_home_toolbar)
+        toolbar.setupHeader2(this, R.string.app_name)
         toolbar.setNavigationOnClickListener { finish() }
-        toolbar.setOnMenuItemClickListener { item ->
-            if (item.itemId == R.id.action_settings) {
-                startActivity(Intent(this, SettingsActivity::class.java))
-                true
-            } else {
-                false
-            }
-        }
 
         val title = intent.getStringExtra(EXTRA_TITLE) ?: ""
         val desc = intent.getStringExtra(EXTRA_DESCRIPTION) ?: ""

--- a/app/src/main/java/com/pnu/pnuguide/ui/course/SpotListActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/course/SpotListActivity.kt
@@ -1,12 +1,11 @@
 package com.pnu.pnuguide.ui.course
 
 import android.os.Bundle
-import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.MaterialToolbar
 import com.pnu.pnuguide.R
-import com.pnu.pnuguide.ui.SettingsActivity
+import com.pnu.pnuguide.ui.HeaderUtils.setupHeader2
 
 class SpotListActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -14,17 +13,8 @@ class SpotListActivity : AppCompatActivity() {
         setContentView(R.layout.activity_spot_list)
 
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_spot_list)
-        setSupportActionBar(toolbar)
-        toolbar.inflateMenu(R.menu.menu_home_toolbar)
+        toolbar.setupHeader2(this, R.string.app_name)
         toolbar.setNavigationOnClickListener { finish() }
-        toolbar.setOnMenuItemClickListener { item ->
-            if (item.itemId == R.id.action_settings) {
-                startActivity(Intent(this, SettingsActivity::class.java))
-                true
-            } else {
-                false
-            }
-        }
 
         // TODO: load spot list
     }

--- a/app/src/main/java/com/pnu/pnuguide/ui/map/DirectionsActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/map/DirectionsActivity.kt
@@ -12,7 +12,7 @@ import androidx.core.content.ContextCompat
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.button.MaterialButton
 import com.pnu.pnuguide.R
-import com.pnu.pnuguide.ui.SettingsActivity
+import com.pnu.pnuguide.ui.HeaderUtils.setupHeader2
 
 class DirectionsActivity : AppCompatActivity() {
 
@@ -27,17 +27,8 @@ class DirectionsActivity : AppCompatActivity() {
         setContentView(R.layout.activity_directions)
 
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_directions)
-        setSupportActionBar(toolbar)
-        toolbar.inflateMenu(R.menu.menu_home_toolbar)
+        toolbar.setupHeader2(this, R.string.get_directions)
         toolbar.setNavigationOnClickListener { finish() }
-        toolbar.setOnMenuItemClickListener { item ->
-            if (item.itemId == R.id.action_settings) {
-                startActivity(Intent(this, SettingsActivity::class.java))
-                true
-            } else {
-                false
-            }
-        }
 
         editStart = findViewById(R.id.edit_start)
         editDestination = findViewById(R.id.edit_destination)

--- a/app/src/main/java/com/pnu/pnuguide/ui/map/MapActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/map/MapActivity.kt
@@ -23,7 +23,7 @@ import com.google.android.gms.maps.model.MarkerOptions
 import com.google.android.material.appbar.MaterialToolbar
 import com.pnu.pnuguide.R
 import com.pnu.pnuguide.MainActivity
-import com.pnu.pnuguide.ui.SettingsActivity
+import com.pnu.pnuguide.ui.HeaderUtils.setupHeader2
 
 class MapActivity : AppCompatActivity(), OnMapReadyCallback {
 
@@ -37,22 +37,12 @@ class MapActivity : AppCompatActivity(), OnMapReadyCallback {
         fusedLocationClient = LocationServices.getFusedLocationProviderClient(this)
 
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_map)
-        setSupportActionBar(toolbar)
-        toolbar.inflateMenu(R.menu.menu_home_toolbar)
-        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        toolbar.setupHeader2(this, R.string.title_map)
         toolbar.setNavigationOnClickListener {
             val intent = Intent(this, MainActivity::class.java)
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
             startActivity(intent)
             finish()
-        }
-        toolbar.setOnMenuItemClickListener { item ->
-            if (item.itemId == R.id.action_settings) {
-                startActivity(Intent(this, SettingsActivity::class.java))
-                true
-            } else {
-                false
-            }
         }
 
         val mapFragment = supportFragmentManager


### PR DESCRIPTION
## Summary
- extract common toolbar logic into `HeaderUtils`
- apply `setupHeader1` or `setupHeader2` across activities

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b5c705948332a143e51609307baa