### PR TITLE
Update toolbar to allow settings nav

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/ui/HeaderUtils.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/HeaderUtils.kt
@@ -7,6 +7,7 @@ import com.google.android.material.appbar.MaterialToolbar
 import androidx.core.content.ContextCompat
 import com.pnu.pnuguide.R
 import com.pnu.pnuguide.ui.map.MapActivity
+import com.pnu.pnuguide.ui.SettingsActivity
 
 fun MaterialToolbar.setupHeader1(activity: AppCompatActivity, titleResId: Int) {
     activity.setSupportActionBar(this)
@@ -33,6 +34,15 @@ fun MaterialToolbar.setupHeader1(activity: AppCompatActivity, titleResId: Int) {
         } else {
             false
         }
+    }
+}
+
+fun MaterialToolbar.setupHeaderSettings(activity: AppCompatActivity, titleResId: Int) {
+    activity.setSupportActionBar(this)
+    this.title = activity.getString(titleResId)
+    this.navigationIcon = ContextCompat.getDrawable(activity, R.drawable.ic_settings)
+    this.setNavigationOnClickListener {
+        activity.startActivity(Intent(activity, SettingsActivity::class.java))
     }
 }
 

--- a/app/src/main/java/com/pnu/pnuguide/ui/HomeActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/HomeActivity.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.appbar.MaterialToolbar
 import com.pnu.pnuguide.R
-import com.pnu.pnuguide.ui.setupHeader1
+import com.pnu.pnuguide.ui.setupHeaderSettings
 
 class HomeActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -12,6 +12,6 @@ class HomeActivity : AppCompatActivity() {
         setContentView(R.layout.activity_home)
 
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_home)
-        toolbar.setupHeader1(this, R.string.title_home)
+        toolbar.setupHeaderSettings(this, R.string.title_home)
     }
 }

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -10,7 +10,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/background_light"
-        android:navigationIcon="@drawable/ic_map"
+        android:navigationIcon="@drawable/ic_settings"
         android:title="@string/title_home"
         android:titleTextColor="@color/text_primary"
         app:titleCentered="true" />


### PR DESCRIPTION
## Summary
- add `setupHeaderSettings` to easily open Settings from the toolbar
- use the new settings navigation style in `HomeActivity`
- update `activity_home` toolbar icon to use the settings icon

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ca496b4c8332a315d4bbe18e0b5f