### PR TITLE
Add course bottom nav with search

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,6 +36,9 @@
         <activity android:name="com.pnu.pnuguide.ui.map.DirectionsActivity" />
         <activity android:name="com.pnu.pnuguide.ui.profile.ProfileActivity" />
         <activity android:name="com.pnu.pnuguide.ui.course.CourseActivity" />
+        <activity android:name="com.pnu.pnuguide.ui.course.PopularActivity" />
+        <activity android:name="com.pnu.pnuguide.ui.course.HistoryActivity" />
+        <activity android:name="com.pnu.pnuguide.ui.course.StudyActivity" />
         <activity android:name="com.pnu.pnuguide.ui.stamp.StampActivity" />
         <activity android:name="com.pnu.pnuguide.ui.chat.ChatActivity" />
         <activity android:name="com.pnu.pnuguide.ui.course.SpotListActivity" />

--- a/app/src/main/java/com/pnu/pnuguide/ui/CourseActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/CourseActivity.kt
@@ -5,13 +5,35 @@ import androidx.appcompat.app.AppCompatActivity
 import android.widget.EditText
 import android.text.TextWatcher
 import android.text.Editable
+import android.view.View
+import android.content.Intent
+import android.widget.TextView
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.pnu.pnuguide.R
+import com.pnu.pnuguide.MainActivity
+import com.pnu.pnuguide.ui.chat.ChatActivity
+import com.pnu.pnuguide.ui.map.MapActivity
+import com.pnu.pnuguide.ui.profile.ProfileActivity
 import com.pnu.pnuguide.ui.setupHeader1
+import com.pnu.pnuguide.ui.course.PopularActivity
+import com.pnu.pnuguide.ui.course.HistoryActivity
+import com.pnu.pnuguide.ui.course.StudyActivity
 
 class CourseActivity : AppCompatActivity() {
     private var searchQuery: String = ""
+    private lateinit var adapter: CourseSearchAdapter
+    private val baseList = listOf(
+        "Campus Highlights Tour",
+        "Historic Landmarks Tour",
+        "Nature Discovery Walk",
+        "Science Exploration Course",
+        "Library Tour"
+    )
+    private val displayList = mutableListOf<String>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -32,15 +54,90 @@ class CourseActivity : AppCompatActivity() {
             .load("https://storage.googleapis.com/tagjs-prod.appspot.com/v1/bnWyQkDlsL/yb4j87iw_expires_30_days.png")
             .into(findViewById(R.id.rzafkzrm2ak))
 
+        val recycler = findViewById<RecyclerView>(R.id.recycler_search)
+        recycler.layoutManager = LinearLayoutManager(this)
+        adapter = CourseSearchAdapter()
+        recycler.adapter = adapter
+        displayList.addAll(baseList)
+        adapter.submitItems(displayList)
+
         val searchEdit: EditText = findViewById(R.id.r9hg358v9thk)
+        searchEdit.setOnFocusChangeListener { _, hasFocus ->
+            if (hasFocus) {
+                findViewById<View>(R.id.rm27nijip3z).visibility = View.GONE
+                recycler.visibility = View.VISIBLE
+            } else if (searchEdit.text.isEmpty()) {
+                recycler.visibility = View.GONE
+                findViewById<View>(R.id.rm27nijip3z).visibility = View.VISIBLE
+            }
+        }
         searchEdit.addTextChangedListener(object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
 
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                 searchQuery = s.toString()
+                filterList()
             }
 
             override fun afterTextChanged(s: Editable?) {}
         })
+
+        recycler.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrolled(rv: RecyclerView, dx: Int, dy: Int) {
+                if (!rv.canScrollVertically(1)) {
+                    val more = if (searchQuery.isEmpty()) baseList else baseList.filter {
+                        it.contains(searchQuery, ignoreCase = true)
+                    }
+                    val start = displayList.size
+                    displayList.addAll(more)
+                    adapter.appendItems(more)
+                    adapter.notifyItemRangeInserted(start, more.size)
+                }
+            }
+        })
+
+        findViewById<TextView>(R.id.rguxz9lullzn).setOnClickListener {
+            startActivity(Intent(this, PopularActivity::class.java))
+        }
+        findViewById<TextView>(R.id.r2qlk2kqy8g4).setOnClickListener {
+            startActivity(Intent(this, HistoryActivity::class.java))
+        }
+        findViewById<TextView>(R.id.rygry7veadsj).setOnClickListener {
+            startActivity(Intent(this, StudyActivity::class.java))
+        }
+
+        val bottomNav = findViewById<BottomNavigationView>(R.id.bottom_nav)
+        bottomNav.setOnItemSelectedListener { menuItem ->
+            when (menuItem.itemId) {
+                R.id.nav_home -> {
+                    startActivity(Intent(this, MainActivity::class.java))
+                    finish()
+                    true
+                }
+                R.id.nav_map -> {
+                    startActivity(Intent(this, MapActivity::class.java))
+                    true
+                }
+                R.id.nav_profile -> {
+                    startActivity(Intent(this, ProfileActivity::class.java))
+                    true
+                }
+                R.id.nav_chat -> {
+                    startActivity(Intent(this, ChatActivity::class.java))
+                    true
+                }
+                else -> false
+            }
+        }
+        bottomNav.selectedItemId = R.id.nav_home
+    }
+
+    private fun filterList() {
+        val filtered = if (searchQuery.isEmpty()) baseList else baseList.filter {
+            it.contains(searchQuery, ignoreCase = true)
+        }
+        displayList.clear()
+        displayList.addAll(filtered)
+        adapter.submitItems(displayList)
     }
 }

--- a/app/src/main/java/com/pnu/pnuguide/ui/course/CourseSearchAdapter.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/course/CourseSearchAdapter.kt
@@ -1,0 +1,40 @@
+package com.pnu.pnuguide.ui.course
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+
+class CourseSearchAdapter : RecyclerView.Adapter<CourseSearchAdapter.ViewHolder>() {
+    private val items = mutableListOf<String>()
+
+    fun submitItems(list: List<String>) {
+        items.clear()
+        items.addAll(list)
+        notifyDataSetChanged()
+    }
+
+    fun appendItems(list: List<String>) {
+        items.addAll(list)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(android.R.layout.simple_list_item_1, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val text: TextView = itemView.findViewById(android.R.id.text1)
+        fun bind(value: String) {
+            text.text = value
+        }
+    }
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/course/HistoryActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/course/HistoryActivity.kt
@@ -1,0 +1,16 @@
+package com.pnu.pnuguide.ui.course
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.appbar.MaterialToolbar
+import com.pnu.pnuguide.R
+import com.pnu.pnuguide.ui.setupHeader2
+
+class HistoryActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_history)
+        val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_history)
+        toolbar.setupHeader2(this, R.string.title_history)
+    }
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/course/PopularActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/course/PopularActivity.kt
@@ -1,0 +1,16 @@
+package com.pnu.pnuguide.ui.course
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.appbar.MaterialToolbar
+import com.pnu.pnuguide.R
+import com.pnu.pnuguide.ui.setupHeader2
+
+class PopularActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_popular)
+        val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_popular)
+        toolbar.setupHeader2(this, R.string.title_popular)
+    }
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/course/StudyActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/course/StudyActivity.kt
@@ -1,0 +1,16 @@
+package com.pnu.pnuguide.ui.course
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.appbar.MaterialToolbar
+import com.pnu.pnuguide.R
+import com.pnu.pnuguide.ui.setupHeader2
+
+class StudyActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_study)
+        val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_study)
+        toolbar.setupHeader2(this, R.string.title_study)
+    }
+}

--- a/app/src/main/res/layout/activity_history.xml
+++ b/app/src/main/res/layout/activity_history.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar_history"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/background_light"
+        android:navigationIcon="@drawable/ic_arrow_back_black_24"
+        android:title="@string/title_history"
+        android:titleTextColor="@color/text_primary"
+        app:titleCentered="true" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="History Course Screen" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_popular.xml
+++ b/app/src/main/res/layout/activity_popular.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar_popular"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/background_light"
+        android:navigationIcon="@drawable/ic_arrow_back_black_24"
+        android:title="@string/title_popular"
+        android:titleTextColor="@color/text_primary"
+        app:titleCentered="true" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="Popular Course Screen" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_study.xml
+++ b/app/src/main/res/layout/activity_study.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar_study"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/background_light"
+        android:navigationIcon="@drawable/ic_arrow_back_black_24"
+        android:title="@string/title_study"
+        android:titleTextColor="@color/text_primary"
+        app:titleCentered="true" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="Study Course Screen" />
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_course.xml
+++ b/app/src/main/res/layout/fragment_course.xml
@@ -259,4 +259,16 @@
             </LinearLayout>
         </LinearLayout>
     </ScrollView>
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_search"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:visibility="gone" />
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottom_nav"
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
+        android:background="@color/background_light"
+        app:menu="@menu/menu_bottom_nav" />
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,5 +25,8 @@
     <string name="title_course">Course</string>
     <string name="title_stamp">Stamp</string>
     <string name="title_chatbot">Chatbot</string>
+    <string name="title_popular">Popular</string>
+    <string name="title_history">History</string>
+    <string name="title_study">Study</string>
     <string name="hint_search_map">Search location</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a RecyclerView and bottom navigation to `fragment_course`
- implement `CourseSearchAdapter` and extend `CourseActivity` with search and bottom nav logic
- add stub activities for Popular, History and Study
- update string resources
- register new activities in the manifest

## Testing
- `./gradlew assembleDebug --dry-run` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856967028748332b17657d3a16cf268