### PR TITLE
Fix course activity navigation

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/ui/CourseActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/CourseActivity.kt
@@ -129,7 +129,7 @@ class CourseActivity : AppCompatActivity() {
                 else -> false
             }
         }
-        bottomNav.selectedItemId = R.id.nav_home
+        bottomNav.menu.findItem(R.id.nav_home).isChecked = true
     }
 
     private fun filterList() {


### PR DESCRIPTION
## Summary
- avoid triggering bottom navigation listener when the Course screen starts

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew testDebugUnitTest --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68569d8f25c08332a01daf7adc490970