### PR TITLE
Improve course search focus behavior

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/ui/CourseActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/CourseActivity.kt
@@ -58,8 +58,8 @@ class CourseActivity : AppCompatActivity() {
         displayList.addAll(baseList)
         adapter.submitItems(displayList)
 
-        val scrollArea: View = findViewById(R.id.rm27nijip3z)
-        val cancelBtn: TextView = findViewById(R.id.btn_cancel_search)
+        val cancelBtn: View = findViewById(R.id.btn_cancel_search)
+        val categoryRow: View = findViewById(R.id.r0ynj2pkd7ew9)
         val sectionPopular: View = findViewById(R.id.section_popular)
         val sectionHistory: View = findViewById(R.id.section_history)
         val sectionStudy: View = findViewById(R.id.section_study)
@@ -71,16 +71,20 @@ class CourseActivity : AppCompatActivity() {
         }
 
         val searchEdit: EditText = findViewById(R.id.r9hg358v9thk)
-        searchEdit.setOnClickListener {
-            if (recycler.visibility != View.VISIBLE) {
-                scrollArea.visibility = View.GONE
+        searchEdit.setOnFocusChangeListener { _, hasFocus ->
+            if (hasFocus && recycler.visibility != View.VISIBLE) {
+                categoryRow.visibility = View.GONE
+                sectionPopular.visibility = View.GONE
+                sectionHistory.visibility = View.GONE
+                sectionStudy.visibility = View.GONE
                 recycler.visibility = View.VISIBLE
                 cancelBtn.visibility = View.VISIBLE
             }
         }
         cancelBtn.setOnClickListener {
             recycler.visibility = View.GONE
-            scrollArea.visibility = View.VISIBLE
+            categoryRow.visibility = View.VISIBLE
+            showSection(sectionPopular)
             cancelBtn.visibility = View.GONE
             searchEdit.text.clear()
             searchEdit.clearFocus()

--- a/app/src/main/res/drawable/ic_close.xml
+++ b/app/src/main/res/drawable/ic_close.xml
@@ -1,0 +1,6 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp" android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#FF000000"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12 19,6.41z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_course.xml
+++ b/app/src/main/res/layout/fragment_course.xml
@@ -90,13 +90,13 @@
                             android:paddingVertical="12dp"
                             android:paddingLeft="8dp"
                             android:paddingRight="16dp" />
-                        <TextView
+                        <ImageButton
                             android:id="@+id/btn_cancel_search"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
+                            android:background="@android:color/transparent"
                             android:padding="12dp"
-                            android:text="Cancel"
-                            android:textColor="#111416"
+                            android:src="@drawable/ic_close"
                             android:visibility="gone" />
                     </LinearLayout>
                     <LinearLayout


### PR DESCRIPTION
## Summary
- hide category sections when search gains focus
- show full list and reveal new close button
- new drawable icon for the close button

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ae4d5ef883328cfcd622d91a0a3e