### PR TITLE
Update history screen with local drawable images

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/ui/course/CourseListAdapter.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/course/CourseListAdapter.kt
@@ -9,7 +9,12 @@ import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.pnu.pnuguide.R
 
-data class CourseItem(val title: String, val duration: String, val imageUrl: String)
+data class CourseItem(
+    val title: String,
+    val duration: String,
+    val imageUrl: String? = null,
+    val imageRes: Int? = null
+)
 
 class CourseListAdapter : RecyclerView.Adapter<CourseListAdapter.CourseViewHolder>() {
     private val items = mutableListOf<CourseItem>()
@@ -37,7 +42,8 @@ class CourseListAdapter : RecyclerView.Adapter<CourseListAdapter.CourseViewHolde
         private val desc: TextView = itemView.findViewById(R.id.text_course_desc)
 
         fun bind(item: CourseItem) {
-            Glide.with(itemView).load(item.imageUrl).into(image)
+            val src = item.imageRes ?: item.imageUrl
+            Glide.with(itemView).load(src).into(image)
             title.text = item.title
             desc.text = item.duration
         }

--- a/app/src/main/java/com/pnu/pnuguide/ui/course/CourseSearchAdapter.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/course/CourseSearchAdapter.kt
@@ -39,7 +39,8 @@ class CourseSearchAdapter : RecyclerView.Adapter<CourseSearchAdapter.ViewHolder>
         private val title: TextView = itemView.findViewById(R.id.text_course_title)
         private val desc: TextView = itemView.findViewById(R.id.text_course_desc)
         fun bind(item: CourseItem) {
-            Glide.with(itemView).load(item.imageUrl).into(image)
+            val src = item.imageRes ?: item.imageUrl
+            Glide.with(itemView).load(src).into(image)
             title.text = item.title
             desc.text = item.duration
         }

--- a/app/src/main/java/com/pnu/pnuguide/ui/course/HistoryActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/course/HistoryActivity.kt
@@ -23,19 +23,19 @@ class HistoryActivity : AppCompatActivity() {
 
         val items = listOf(
             CourseItem(
-                "Historic Landmarks Tour",
-                "Approx. 2 hours",
-                "https://storage.googleapis.com/tagjs-prod.appspot.com/v1/bnWyQkDlsL/z7s2j8n3_expires_30_days.png"
+                "박물관",
+                "건물 번호: 412",
+                imageRes = R.drawable.museum
             ),
             CourseItem(
-                "Museum Exploration",
-                "Approx. 3 hours",
-                "https://storage.googleapis.com/tagjs-prod.appspot.com/v1/bnWyQkDlsL/hc760uhy_expires_30_days.png"
+                "지질박물관",
+                "건물 번호: 414",
+                imageRes = R.drawable.jijil
             ),
             CourseItem(
-                "Cultural Heritage Walk",
-                "Approx. 1.5 hours",
-                "https://storage.googleapis.com/tagjs-prod.appspot.com/v1/bnWyQkDlsL/yb4j87iw_expires_30_days.png"
+                "중앙 도서관",
+                "건물 번호: 510",
+                imageRes = R.drawable.ang
             )
         )
         adapter.submitList(items)


### PR DESCRIPTION
## Summary
- handle drawable resources in CourseItem
- update adapter logic to load local drawables
- modify HistoryActivity items to use drawable images

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c06701b083328c139728af534c6e