### PR TITLE
Update history cards on course screen

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/ui/CourseActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/CourseActivity.kt
@@ -10,6 +10,7 @@ import android.content.Intent
 import android.widget.TextView
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import android.widget.ImageView
 import com.bumptech.glide.Glide
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.bottomnavigation.BottomNavigationView
@@ -60,15 +61,9 @@ class CourseActivity : AppCompatActivity() {
         Glide.with(this)
             .load("https://storage.googleapis.com/tagjs-prod.appspot.com/v1/bnWyQkDlsL/yb4j87iw_expires_30_days.png")
             .into(findViewById(R.id.rzafkzrm2ak))
-        Glide.with(this)
-            .load("https://storage.googleapis.com/tagjs-prod.appspot.com/v1/bnWyQkDlsL/z7s2j8n3_expires_30_days.png")
-            .into(findViewById(R.id.image_history_1))
-        Glide.with(this)
-            .load("https://storage.googleapis.com/tagjs-prod.appspot.com/v1/bnWyQkDlsL/hc760uhy_expires_30_days.png")
-            .into(findViewById(R.id.image_history_2))
-        Glide.with(this)
-            .load("https://storage.googleapis.com/tagjs-prod.appspot.com/v1/bnWyQkDlsL/yb4j87iw_expires_30_days.png")
-            .into(findViewById(R.id.image_history_3))
+        findViewById<ImageView>(R.id.image_history_1).setImageResource(R.drawable.museum)
+        findViewById<ImageView>(R.id.image_history_2).setImageResource(R.drawable.jijil)
+        findViewById<ImageView>(R.id.image_history_3).setImageResource(R.drawable.ang)
         Glide.with(this)
             .load("https://storage.googleapis.com/tagjs-prod.appspot.com/v1/bnWyQkDlsL/z7s2j8n3_expires_30_days.png")
             .into(findViewById(R.id.image_study_1))

--- a/app/src/main/java/com/pnu/pnuguide/ui/course/CourseListAdapter.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/course/CourseListAdapter.kt
@@ -9,7 +9,12 @@ import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.pnu.pnuguide.R
 
-data class CourseItem(val title: String, val duration: String, val imageUrl: String)
+data class CourseItem(
+    val title: String,
+    val duration: String,
+    val imageUrl: String? = null,
+    val imageRes: Int? = null
+)
 
 class CourseListAdapter : RecyclerView.Adapter<CourseListAdapter.CourseViewHolder>() {
     private val items = mutableListOf<CourseItem>()
@@ -37,7 +42,8 @@ class CourseListAdapter : RecyclerView.Adapter<CourseListAdapter.CourseViewHolde
         private val desc: TextView = itemView.findViewById(R.id.text_course_desc)
 
         fun bind(item: CourseItem) {
-            Glide.with(itemView).load(item.imageUrl).into(image)
+            val src = item.imageRes ?: item.imageUrl
+            Glide.with(itemView).load(src).into(image)
             title.text = item.title
             desc.text = item.duration
         }

--- a/app/src/main/java/com/pnu/pnuguide/ui/course/CourseSearchAdapter.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/course/CourseSearchAdapter.kt
@@ -39,7 +39,8 @@ class CourseSearchAdapter : RecyclerView.Adapter<CourseSearchAdapter.ViewHolder>
         private val title: TextView = itemView.findViewById(R.id.text_course_title)
         private val desc: TextView = itemView.findViewById(R.id.text_course_desc)
         fun bind(item: CourseItem) {
-            Glide.with(itemView).load(item.imageUrl).into(image)
+            val src = item.imageRes ?: item.imageUrl
+            Glide.with(itemView).load(src).into(image)
             title.text = item.title
             desc.text = item.duration
         }

--- a/app/src/main/java/com/pnu/pnuguide/ui/course/HistoryActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/course/HistoryActivity.kt
@@ -23,19 +23,19 @@ class HistoryActivity : AppCompatActivity() {
 
         val items = listOf(
             CourseItem(
-                "Historic Landmarks Tour",
-                "Approx. 2 hours",
-                "https://storage.googleapis.com/tagjs-prod.appspot.com/v1/bnWyQkDlsL/z7s2j8n3_expires_30_days.png"
+                "박물관",
+                "건물 번호: 412",
+                imageRes = R.drawable.museum
             ),
             CourseItem(
-                "Museum Exploration",
-                "Approx. 3 hours",
-                "https://storage.googleapis.com/tagjs-prod.appspot.com/v1/bnWyQkDlsL/hc760uhy_expires_30_days.png"
+                "지질박물관",
+                "건물 번호: 414",
+                imageRes = R.drawable.jijil
             ),
             CourseItem(
-                "Cultural Heritage Walk",
-                "Approx. 1.5 hours",
-                "https://storage.googleapis.com/tagjs-prod.appspot.com/v1/bnWyQkDlsL/yb4j87iw_expires_30_days.png"
+                "중앙 도서관",
+                "건물 번호: 510",
+                imageRes = R.drawable.ang
             )
         )
         adapter.submitList(items)

--- a/app/src/main/res/layout/fragment_course.xml
+++ b/app/src/main/res/layout/fragment_course.xml
@@ -74,7 +74,7 @@
                                 android:id="@+id/rs49bgap0hwg"
                                 android:layout_width="24dp"
                                 android:layout_height="24dp"
-                                android:src="@mipmap/ic_launcher"
+                                android:src="@drawable/museum"
                                 android:scaleType="fitXY" />
                         </LinearLayout>
                         <EditText
@@ -289,7 +289,7 @@
                                 android:layout_width="100dp"
                                 android:layout_height="56dp"
                                 android:layout_marginEnd="16dp"
-                                android:src="@mipmap/ic_launcher"
+                                android:src="@drawable/jijil"
                                 android:scaleType="fitXY" />
                             <LinearLayout
                                 android:layout_width="wrap_content"
@@ -299,7 +299,7 @@
                                     android:id="@+id/text_history_title_1"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:text="Historic Landmarks Tour"
+                                    android:text="박물관"
                                     android:textColor="#111416"
                                     android:textSize="16sp"
                                     android:textStyle="bold" />
@@ -308,7 +308,7 @@
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
                                     android:layout_marginEnd="79dp"
-                                    android:text="Approx. 2 hours"
+                                    android:text="건물 번호: 412"
                                     android:textColor="#667582"
                                     android:textSize="14sp" />
                             </LinearLayout>
@@ -327,7 +327,7 @@
                                 android:layout_width="100dp"
                                 android:layout_height="56dp"
                                 android:layout_marginEnd="16dp"
-                                android:src="@mipmap/ic_launcher"
+                                android:src="@drawable/jijil"
                                 android:scaleType="fitXY" />
                             <LinearLayout
                                 android:layout_width="wrap_content"
@@ -337,7 +337,7 @@
                                     android:id="@+id/text_history_title_2"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:text="Museum Exploration"
+                                    android:text="지질박물관"
                                     android:textColor="#111416"
                                     android:textSize="16sp"
                                     android:textStyle="bold" />
@@ -346,7 +346,7 @@
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
                                     android:layout_marginEnd="79dp"
-                                    android:text="Approx. 3 hours"
+                                    android:text="건물 번호: 414"
                                     android:textColor="#667582"
                                     android:textSize="14sp" />
                             </LinearLayout>
@@ -365,7 +365,7 @@
                                 android:layout_width="100dp"
                                 android:layout_height="56dp"
                                 android:layout_marginEnd="16dp"
-                                android:src="@mipmap/ic_launcher"
+                                android:src="@drawable/ang"
                                 android:scaleType="fitXY" />
                             <LinearLayout
                                 android:layout_width="wrap_content"
@@ -375,7 +375,7 @@
                                     android:id="@+id/text_history_title_3"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
-                                    android:text="Cultural Heritage Walk"
+                                    android:text="중앙 도서관"
                                     android:textColor="#111416"
                                     android:textSize="16sp"
                                     android:textStyle="bold" />
@@ -384,7 +384,7 @@
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
                                     android:layout_marginEnd="79dp"
-                                    android:text="Approx. 1.5 hours"
+                                    android:text="건물 번호: 510"
                                     android:textColor="#667582"
                                     android:textSize="14sp" />
                             </LinearLayout>


### PR DESCRIPTION
## Summary
- switch history card drawables to local images
- show Korean titles and building numbers on main course screen
- reference local drawables from code

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856c06701b083328c139728af534c6e