### PR TITLE
Add modal dialogs for course cards

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/ui/CourseActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/CourseActivity.kt
@@ -92,6 +92,10 @@ class CourseActivity : AppCompatActivity() {
         recycler.layoutManager = LinearLayoutManager(this)
         adapter = CourseSearchAdapter()
         recycler.adapter = adapter
+        adapter.onItemClick = { item ->
+            SpotDetailDialogFragment.newInstance(item)
+                .show(supportFragmentManager, "detail")
+        }
         displayList.addAll(baseList)
         adapter.submitItems(displayList)
 
@@ -101,6 +105,40 @@ class CourseActivity : AppCompatActivity() {
         val sectionPopular: View = findViewById(R.id.section_popular)
         val sectionHistory: View = findViewById(R.id.section_history)
         val sectionStudy: View = findViewById(R.id.section_study)
+
+        fun showDetail(title: String, desc: String, image: Int) {
+            val item = CourseItem(title, desc, imageRes = image)
+            SpotDetailDialogFragment.newInstance(item)
+                .show(supportFragmentManager, "detail")
+        }
+
+        findViewById<View>(R.id.r4426ybbx5od).setOnClickListener {
+            showDetail("새벽벌 도서관", "건물번호: 420", R.drawable.sae_do)
+        }
+        findViewById<View>(R.id.r0r21uflcziqi).setOnClickListener {
+            showDetail("PNU V-SPACE", "건물번호: 303", R.drawable.vs)
+        }
+        findViewById<View>(R.id.r0augc34kguoi).setOnClickListener {
+            showDetail("법학관 모의 법정", "건물번호: 609", R.drawable.beopjeong)
+        }
+        findViewById<View>(R.id.card_history_1).setOnClickListener {
+            showDetail("박물관", "건물 번호: 412", R.drawable.museum)
+        }
+        findViewById<View>(R.id.card_history_2).setOnClickListener {
+            showDetail("지질박물관", "건물 번호: 414", R.drawable.jijil)
+        }
+        findViewById<View>(R.id.card_history_3).setOnClickListener {
+            showDetail("중앙 도서관", "건물 번호: 510", R.drawable.ang)
+        }
+        findViewById<View>(R.id.card_study_1).setOnClickListener {
+            showDetail("넉넉한 터", "건물번호: 203", R.drawable.nuck)
+        }
+        findViewById<View>(R.id.card_study_2).setOnClickListener {
+            showDetail("cafe 운죽정", "건물번호: 202", R.drawable.cafe)
+        }
+        findViewById<View>(R.id.card_study_3).setOnClickListener {
+            showDetail("진리의 뜰", "운죽정 뒷편", R.drawable.jinli)
+        }
 
         fun showSection(target: View) {
             sectionPopular.visibility = if (target == sectionPopular) View.VISIBLE else View.GONE

--- a/app/src/main/java/com/pnu/pnuguide/ui/course/CourseListAdapter.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/course/CourseListAdapter.kt
@@ -18,6 +18,7 @@ data class CourseItem(
 
 class CourseListAdapter : RecyclerView.Adapter<CourseListAdapter.CourseViewHolder>() {
     private val items = mutableListOf<CourseItem>()
+    var onItemClick: ((CourseItem) -> Unit)? = null
 
     fun submitList(list: List<CourseItem>) {
         items.clear()
@@ -31,7 +32,11 @@ class CourseListAdapter : RecyclerView.Adapter<CourseListAdapter.CourseViewHolde
     }
 
     override fun onBindViewHolder(holder: CourseViewHolder, position: Int) {
-        holder.bind(items[position])
+        val item = items[position]
+        holder.bind(item)
+        holder.itemView.setOnClickListener {
+            onItemClick?.invoke(item)
+        }
     }
 
     override fun getItemCount(): Int = items.size

--- a/app/src/main/java/com/pnu/pnuguide/ui/course/CourseSearchAdapter.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/course/CourseSearchAdapter.kt
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.RecyclerView
 
 class CourseSearchAdapter : RecyclerView.Adapter<CourseSearchAdapter.ViewHolder>() {
     private val items = mutableListOf<CourseItem>()
+    var onItemClick: ((CourseItem) -> Unit)? = null
 
     fun submitItems(list: List<CourseItem>) {
         items.clear()
@@ -29,7 +30,9 @@ class CourseSearchAdapter : RecyclerView.Adapter<CourseSearchAdapter.ViewHolder>
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.bind(items[position])
+        val item = items[position]
+        holder.bind(item)
+        holder.itemView.setOnClickListener { onItemClick?.invoke(item) }
     }
 
     override fun getItemCount(): Int = items.size

--- a/app/src/main/java/com/pnu/pnuguide/ui/course/HistoryActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/course/HistoryActivity.kt
@@ -20,6 +20,10 @@ class HistoryActivity : AppCompatActivity() {
         recycler.layoutManager = LinearLayoutManager(this)
         val adapter = CourseListAdapter()
         recycler.adapter = adapter
+        adapter.onItemClick = { item ->
+            SpotDetailDialogFragment.newInstance(item)
+                .show(supportFragmentManager, "detail")
+        }
 
         val items = listOf(
             CourseItem(

--- a/app/src/main/java/com/pnu/pnuguide/ui/course/PopularActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/course/PopularActivity.kt
@@ -20,6 +20,10 @@ class PopularActivity : AppCompatActivity() {
         recycler.layoutManager = LinearLayoutManager(this)
         val adapter = CourseListAdapter()
         recycler.adapter = adapter
+        adapter.onItemClick = { item ->
+            SpotDetailDialogFragment.newInstance(item)
+                .show(supportFragmentManager, "detail")
+        }
 
         val items = listOf(
             CourseItem(

--- a/app/src/main/java/com/pnu/pnuguide/ui/course/SpotDetailDialogFragment.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/course/SpotDetailDialogFragment.kt
@@ -1,0 +1,73 @@
+package com.pnu.pnuguide.ui.course
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import com.bumptech.glide.Glide
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.pnu.pnuguide.R
+import com.pnu.pnuguide.ui.quiz.QuizActivity
+import com.pnu.pnuguide.ui.stamp.StampActivity
+
+class SpotDetailDialogFragment : BottomSheetDialogFragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.dialog_spot_detail, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        val title = requireArguments().getString(ARG_TITLE, "")
+        val desc = requireArguments().getString(ARG_DESC, "")
+        val imageRes = requireArguments().getInt(ARG_IMAGE_RES)
+        val imageUrl = requireArguments().getString(ARG_IMAGE_URL)
+
+        val imageView = view.findViewById<ImageView>(R.id.image_detail)
+        if (imageUrl != null) {
+            Glide.with(this).load(imageUrl).into(imageView)
+        } else if (imageRes != 0) {
+            imageView.setImageResource(imageRes)
+        }
+
+        view.findViewById<TextView>(R.id.text_detail_title).text = title
+        view.findViewById<TextView>(R.id.text_detail_desc).text = desc
+
+        view.findViewById<MaterialButton>(R.id.button_camera).setOnClickListener {
+            startActivity(Intent(requireContext(), StampActivity::class.java))
+            dismiss()
+        }
+        view.findViewById<MaterialButton>(R.id.button_quiz).setOnClickListener {
+            val intent = Intent(requireContext(), QuizActivity::class.java)
+            intent.putExtra(QuizActivity.EXTRA_TITLE, title)
+            startActivity(intent)
+            dismiss()
+        }
+    }
+
+    companion object {
+        private const val ARG_TITLE = "arg_title"
+        private const val ARG_DESC = "arg_desc"
+        private const val ARG_IMAGE_RES = "arg_image_res"
+        private const val ARG_IMAGE_URL = "arg_image_url"
+
+        fun newInstance(item: CourseItem): SpotDetailDialogFragment {
+            val f = SpotDetailDialogFragment()
+            val args = Bundle()
+            args.putString(ARG_TITLE, item.title)
+            args.putString(ARG_DESC, item.duration)
+            item.imageRes?.let { args.putInt(ARG_IMAGE_RES, it) }
+            item.imageUrl?.let { args.putString(ARG_IMAGE_URL, it) }
+            f.arguments = args
+            return f
+        }
+    }
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/course/SpotListActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/course/SpotListActivity.kt
@@ -21,6 +21,10 @@ class SpotListActivity : AppCompatActivity() {
         recycler.layoutManager = LinearLayoutManager(this)
         val adapter = CourseListAdapter()
         recycler.adapter = adapter
+        adapter.onItemClick = { item ->
+            SpotDetailDialogFragment.newInstance(item)
+                .show(supportFragmentManager, "detail")
+        }
 
         val items = listOf(
             CourseItem(

--- a/app/src/main/java/com/pnu/pnuguide/ui/course/StudyActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/course/StudyActivity.kt
@@ -20,6 +20,10 @@ class StudyActivity : AppCompatActivity() {
         recycler.layoutManager = LinearLayoutManager(this)
         val adapter = CourseListAdapter()
         recycler.adapter = adapter
+        adapter.onItemClick = { item ->
+            SpotDetailDialogFragment.newInstance(item)
+                .show(supportFragmentManager, "detail")
+        }
 
         val items = listOf(
             CourseItem(

--- a/app/src/main/java/com/pnu/pnuguide/ui/quiz/QuizActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/quiz/QuizActivity.kt
@@ -1,0 +1,22 @@
+package com.pnu.pnuguide.ui.quiz
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.appbar.MaterialToolbar
+import com.pnu.pnuguide.R
+import com.pnu.pnuguide.ui.setupHeader1
+
+class QuizActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_quiz)
+
+        val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_quiz)
+        toolbar.setupHeader1(this, R.string.title_quiz)
+        toolbar.setNavigationOnClickListener { finish() }
+    }
+
+    companion object {
+        const val EXTRA_TITLE = "extra_title"
+    }
+}

--- a/app/src/main/res/layout/activity_quiz.xml
+++ b/app/src/main/res/layout/activity_quiz.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar_quiz"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/background_light"
+        android:navigationIcon="@drawable/ic_arrow_back_black_24"
+        android:title="@string/title_quiz"
+        android:titleTextColor="@color/text_primary"
+        app:titleCentered="true" />
+
+    <TextView
+        android:id="@+id/text_quiz_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Quiz"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        android:padding="16dp" />
+
+    <!-- Quiz content placeholder -->
+
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_spot_detail.xml
+++ b/app/src/main/res/layout/dialog_spot_detail.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="16dp"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ImageView
+        android:id="@+id/image_detail"
+        android:layout_width="match_parent"
+        android:layout_height="200dp"
+        android:scaleType="centerCrop" />
+
+    <TextView
+        android:id="@+id/text_detail_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        android:paddingTop="8dp" />
+
+    <TextView
+        android:id="@+id/text_detail_desc"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="4dp"
+        android:textSize="14sp" />
+
+    <LinearLayout
+        android:orientation="horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="end"
+        android:paddingTop="16dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/button_camera"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/action_camera"
+            android:icon="@android:drawable/ic_menu_camera" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/button_quiz"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/action_quiz"
+            android:icon="@android:drawable/ic_menu_help" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,5 +28,8 @@
     <string name="title_popular">Popular</string>
     <string name="title_history">History</string>
     <string name="title_study">Study</string>
+    <string name="title_quiz">Quiz</string>
+    <string name="action_camera">Camera</string>
+    <string name="action_quiz">Quiz</string>
     <string name="hint_search_map">Search location</string>
 </resources>


### PR DESCRIPTION
## Summary
- show a detail bottom sheet when tapping course cards
- add camera and quiz buttons inside the dialog
- create QuizActivity
- enable item click handling on course adapters

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856d94b9fa08332bc5d08d93ebdde35