### PR TITLE
Improve course search real-time update

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/ui/CourseActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/CourseActivity.kt
@@ -170,6 +170,22 @@ class CourseActivity : AppCompatActivity() {
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                 searchQuery = s.toString()
                 filterList()
+
+                if (s.isNullOrEmpty()) {
+                    recycler.visibility = View.GONE
+                    categoryRow.visibility = View.VISIBLE
+                    showSection(sectionPopular)
+                    scrollView.visibility = View.VISIBLE
+                    cancelBtn.visibility = View.GONE
+                } else if (recycler.visibility != View.VISIBLE) {
+                    categoryRow.visibility = View.GONE
+                    sectionPopular.visibility = View.GONE
+                    sectionHistory.visibility = View.GONE
+                    sectionStudy.visibility = View.GONE
+                    scrollView.visibility = View.GONE
+                    recycler.visibility = View.VISIBLE
+                    cancelBtn.visibility = View.VISIBLE
+                }
             }
 
             override fun afterTextChanged(s: Editable?) {}


### PR DESCRIPTION
## Summary
- update CourseActivity text watcher to toggle search results and sections in real-time

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f2b18030833284b6c7b838313ae7