### PR TITLE
Add PDF download on Stamp screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,16 @@
         <activity android:name="com.pnu.pnuguide.ui.LoginActivity" />
         <activity android:name="com.pnu.pnuguide.ui.signup.SignUpActivity" />
         <activity android:name=".MainActivity" />
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
         <activity android:name="com.pnu.pnuguide.ui.home.HomeActivity" />
         <activity android:name="com.pnu.pnuguide.ui.map.MapActivity" />
         <activity android:name="com.pnu.pnuguide.ui.map.DirectionsActivity" />

--- a/app/src/main/java/com/pnu/pnuguide/ui/StampActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/StampActivity.kt
@@ -2,6 +2,12 @@ package com.pnu.pnuguide.ui.stamp
 
 import android.os.Bundle
 import android.content.Intent
+import android.content.res.Resources
+import android.net.Uri
+import com.google.android.material.button.MaterialButton
+import androidx.core.content.FileProvider
+import java.io.File
+import java.io.FileOutputStream
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.bottomnavigation.BottomNavigationView
@@ -19,6 +25,10 @@ class StampActivity : AppCompatActivity() {
 
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_stamp)
         toolbar.setupHeader1(this, R.string.title_stamp)
+
+        findViewById<MaterialButton>(R.id.btn_download_pdf).setOnClickListener {
+            openCampusMapPdf()
+        }
 
         val bottomNav = findViewById<BottomNavigationView>(R.id.bottom_nav)
         bottomNav.setOnItemSelectedListener { menuItem ->
@@ -44,5 +54,21 @@ class StampActivity : AppCompatActivity() {
             }
         }
         bottomNav.menu.findItem(R.id.nav_home).isChecked = true
+    }
+
+    private fun openCampusMapPdf() {
+        val inputStream = resources.openRawResource(R.raw.campus_map)
+        val file = File(getExternalFilesDir(null), "campus_map.pdf")
+        if (!file.exists()) {
+            FileOutputStream(file).use { output ->
+                inputStream.copyTo(output)
+            }
+        }
+        val uri: Uri = FileProvider.getUriForFile(this, "${packageName}.provider", file)
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, "application/pdf")
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        startActivity(intent)
     }
 }

--- a/app/src/main/res/layout/fragment_stamp.xml
+++ b/app/src/main/res/layout/fragment_stamp.xml
@@ -20,11 +20,24 @@
         android:layout_height="0dp"
         android:layout_weight="1">
 
-        <TextView
-            android:id="@+id/text_stamp"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Stamp Fragment" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/text_stamp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Stamp Fragment" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btn_download_pdf"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/download_map" />
+        </LinearLayout>
     </FrameLayout>
 
     <com.google.android.material.bottomnavigation.BottomNavigationView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,4 +32,5 @@
     <string name="action_camera">Camera</string>
     <string name="action_quiz">Quiz</string>
     <string name="hint_search_map">Search location</string>
+    <string name="download_map">Download Campus Map</string>
 </resources>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-files-path name="external_files" path="." />
+</paths>


### PR DESCRIPTION
## Summary
- enable campus map PDF download via `FileProvider`
- add download button in the stamp layout
- add provider declaration in the manifest
- update strings

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856fb97437883329f5c03e9d77da621