### PR TITLE
Update chat header and bottom navigation

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/MainActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.fragment.app.commit
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.pnu.pnuguide.ui.SettingsActivity
+import com.pnu.pnuguide.ui.setupHeader2
 import com.pnu.pnuguide.ui.home.HomeFragment
 import com.pnu.pnuguide.ui.map.MapActivity
 import com.pnu.pnuguide.ui.chat.ChatFragment
@@ -54,12 +55,7 @@ class MainActivity : AppCompatActivity() {
                     true
                 }
                 R.id.nav_chat -> {
-                    toolbar.title = getString(R.string.title_chatbot)
-                    supportActionBar?.setDisplayHomeAsUpEnabled(false)
-                    toolbar.setNavigationIcon(R.drawable.ic_map)
-                    toolbar.setNavigationOnClickListener {
-                        startActivity(Intent(this, MapActivity::class.java))
-                    }
+                    toolbar.setupHeader2(this, R.string.title_chatbot)
                     supportFragmentManager.commit {
                         replace(R.id.fragment_container, ChatFragment())
                     }

--- a/app/src/main/java/com/pnu/pnuguide/ui/ChatActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/ChatActivity.kt
@@ -4,7 +4,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.appbar.MaterialToolbar
 import com.pnu.pnuguide.R
-import com.pnu.pnuguide.ui.setupHeader1
+import com.pnu.pnuguide.ui.setupHeader2
 
 class ChatActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -12,6 +12,6 @@ class ChatActivity : AppCompatActivity() {
         setContentView(R.layout.activity_chat)
 
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_chat)
-        toolbar.setupHeader1(this, R.string.title_chatbot)
+        toolbar.setupHeader2(this, R.string.title_chatbot)
     }
 }

--- a/app/src/main/res/drawable/ic_course.xml
+++ b/app/src/main/res/drawable/ic_course.xml
@@ -2,5 +2,5 @@
     android:width="24dp" android:height="24dp" android:viewportWidth="24"
     android:viewportHeight="24">
     <path android:fillColor="#FF000000"
-        android:pathData="M20.5,3l-5.5,2.5-6-2.5-6.5,2.5v15l6.5-2.5 6,2.5 6.5-2.5v-15zM9,4.75l4,1.75v12.75l-4-1.75V4.75zM4,6.3l4-1.55v12.75l-4,1.55V6.3zM18,18.7l-4,1.55V7.5l4-1.55V18.7z"/>
+        android:pathData="M18 2H6c-1.1 0-2 .9-2 2v16c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zM6 4h5v8l-2.5-1.5L6 12V4z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_stamp.xml
+++ b/app/src/main/res/drawable/ic_stamp.xml
@@ -2,5 +2,5 @@
     android:width="24dp" android:height="24dp" android:viewportWidth="24"
     android:viewportHeight="24">
     <path android:fillColor="#FF000000"
-        android:pathData="M12,17.27L18.18,21 16.54,13.97 22,9.24 14.81,8.62 12,2 9.19,8.63 2,9.24 7.46,13.97 5.82,21z"/>
+        android:pathData="M4 16v6h16v-6c0-1.1-.9-2-2-2H6c-1.1 0-2 .9-2 2zm14 2H6v-2h12v2zM12 2C9.24 2 7 4.24 7 7l5 7 5-7c0-2.76-2.24-5-5-5zm0 9L9 7c0-1.66 1.34-3 3-3s3 1.34 3 3l-3 4z"/>
 </vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -29,6 +29,8 @@
         android:layout_height="72dp"
         android:background="@color/background_light"
         app:itemIconSize="32dp"
+        app:labelVisibilityMode="labeled"
+        app:itemHorizontalTranslationEnabled="false"
         app:menu="@menu/menu_bottom_nav" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_course.xml
+++ b/app/src/main/res/layout/fragment_course.xml
@@ -527,5 +527,7 @@
         android:layout_height="72dp"
         android:background="@color/background_light"
         app:itemIconSize="32dp"
+        app:labelVisibilityMode="labeled"
+        app:itemHorizontalTranslationEnabled="false"
         app:menu="@menu/menu_bottom_nav" />
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_stamp.xml
+++ b/app/src/main/res/layout/fragment_stamp.xml
@@ -46,5 +46,7 @@
         android:layout_height="72dp"
         android:background="@color/background_light"
         app:itemIconSize="32dp"
+        app:labelVisibilityMode="labeled"
+        app:itemHorizontalTranslationEnabled="false"
         app:menu="@menu/menu_bottom_nav" />
 </LinearLayout>


### PR DESCRIPTION
## Summary
- show a back button on ChatActivity and chat tab
- keep bottom navigation labels below icons
- replace Course and Stamp icons

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685703e821b88332a1f7971bcb6e9468