### PR TITLE
Fix chat header

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/MainActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/MainActivity.kt
@@ -10,7 +10,7 @@ import com.pnu.pnuguide.ui.SettingsActivity
 import com.pnu.pnuguide.ui.setupHeader2
 import com.pnu.pnuguide.ui.home.HomeFragment
 import com.pnu.pnuguide.ui.map.MapActivity
-import com.pnu.pnuguide.ui.chat.ChatFragment
+import com.pnu.pnuguide.ui.chat.ChatActivity
 import com.pnu.pnuguide.ui.course.CourseActivity
 import com.pnu.pnuguide.ui.stamp.StampActivity
 
@@ -57,10 +57,7 @@ class MainActivity : AppCompatActivity() {
                     true
                 }
                 R.id.nav_chat -> {
-                    toolbar.setupHeader2(this, R.string.title_chatbot)
-                    supportFragmentManager.commit {
-                        replace(R.id.fragment_container, ChatFragment())
-                    }
+                    startActivity(Intent(this, ChatActivity::class.java))
                     true
                 }
                 else -> false

--- a/app/src/main/java/com/pnu/pnuguide/ui/ChatActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/ChatActivity.kt
@@ -2,7 +2,13 @@ package com.pnu.pnuguide.ui.chat
 
 import android.os.Bundle
 import android.content.Intent
+import android.widget.Button
+import android.widget.EditText
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.pnu.pnuguide.R
@@ -10,14 +16,39 @@ import com.pnu.pnuguide.MainActivity
 import com.pnu.pnuguide.ui.course.CourseActivity
 import com.pnu.pnuguide.ui.stamp.StampActivity
 import com.pnu.pnuguide.ui.setupHeader1
+import com.pnu.pnuguide.ui.chat.ChatAdapter
+import com.pnu.pnuguide.ui.chat.ChatViewModel
+import kotlinx.coroutines.flow.collectLatest
 
 class ChatActivity : AppCompatActivity() {
+
+    private val viewModel by viewModels<ChatViewModel>()
+    private lateinit var adapter: ChatAdapter
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_chat)
 
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_chat)
         toolbar.setupHeader1(this, R.string.title_chatbot)
+
+        adapter = ChatAdapter()
+        val recycler = findViewById<RecyclerView>(R.id.recycler_chat)
+        recycler.layoutManager = LinearLayoutManager(this)
+        recycler.adapter = adapter
+
+        val edit = findViewById<EditText>(R.id.edit_message)
+        findViewById<Button>(R.id.button_send).setOnClickListener {
+            val text = edit.text.toString().trim()
+            if (text.isNotEmpty()) {
+                viewModel.sendMessage(text)
+                edit.setText("")
+            }
+        }
+
+        lifecycleScope.launchWhenStarted {
+            viewModel.messages.collectLatest { adapter.submitList(it) }
+        }
 
         val bottomNav = findViewById<BottomNavigationView>(R.id.bottom_nav)
         bottomNav.setOnItemSelectedListener { menuItem ->


### PR DESCRIPTION
## Summary
- display working chat UI inside `ChatActivity`
- open `ChatActivity` from main bottom nav so header1 always shows

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68571638f6d483329876e554eb81bfcb