### PR TITLE
Enlarge bottom navigation

### DIFF
--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -44,12 +44,14 @@
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottom_nav"
         android:layout_width="match_parent"
-        android:layout_height="72dp"
+        android:layout_height="@dimen/bottom_nav_height"
         android:background="@color/background_light"
         android:paddingTop="4dp"
         android:paddingBottom="4dp"
-        app:itemIconSize="32dp"
-        app:labelVisibilityMode="labeled"
+        app:itemIconSize="@dimen/bottom_nav_icon_size"
+        app:labelVisibilityMode="unlabeled"
         app:itemHorizontalTranslationEnabled="false"
         app:menu="@menu/menu_bottom_nav" />
+
+    <include layout="@layout/bottom_nav_labels" />
 </LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -26,13 +26,15 @@
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottom_nav"
         android:layout_width="match_parent"
-        android:layout_height="72dp"
+        android:layout_height="@dimen/bottom_nav_height"
         android:background="@color/background_light"
         android:paddingTop="4dp"
         android:paddingBottom="4dp"
-        app:itemIconSize="32dp"
-        app:labelVisibilityMode="labeled"
+        app:itemIconSize="@dimen/bottom_nav_icon_size"
+        app:labelVisibilityMode="unlabeled"
         app:itemHorizontalTranslationEnabled="false"
         app:menu="@menu/menu_bottom_nav" />
+
+    <include layout="@layout/bottom_nav_labels" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/bottom_nav_labels.xml
+++ b/app/src/main/res/layout/bottom_nav_labels.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:background="@color/background_light"
+    android:paddingTop="4dp"
+    android:paddingBottom="8dp">
+
+    <TextView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:text="@string/title_home"
+        android:textColor="@color/text_primary"
+        android:textSize="14sp" />
+
+    <TextView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:text="@string/title_course"
+        android:textColor="@color/text_primary"
+        android:textSize="14sp" />
+
+    <TextView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:text="@string/title_stamp"
+        android:textColor="@color/text_primary"
+        android:textSize="14sp" />
+
+    <TextView
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:text="@string/title_chatbot"
+        android:textColor="@color/text_primary"
+        android:textSize="14sp" />
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_course.xml
+++ b/app/src/main/res/layout/fragment_course.xml
@@ -524,12 +524,14 @@
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottom_nav"
         android:layout_width="match_parent"
-        android:layout_height="72dp"
+        android:layout_height="@dimen/bottom_nav_height"
         android:background="@color/background_light"
         android:paddingTop="4dp"
         android:paddingBottom="4dp"
-        app:itemIconSize="32dp"
-        app:labelVisibilityMode="labeled"
+        app:itemIconSize="@dimen/bottom_nav_icon_size"
+        app:labelVisibilityMode="unlabeled"
         app:itemHorizontalTranslationEnabled="false"
         app:menu="@menu/menu_bottom_nav" />
+
+    <include layout="@layout/bottom_nav_labels" />
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_stamp.xml
+++ b/app/src/main/res/layout/fragment_stamp.xml
@@ -43,12 +43,14 @@
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottom_nav"
         android:layout_width="match_parent"
-        android:layout_height="72dp"
+        android:layout_height="@dimen/bottom_nav_height"
         android:background="@color/background_light"
         android:paddingTop="4dp"
         android:paddingBottom="4dp"
-        app:itemIconSize="32dp"
-        app:labelVisibilityMode="labeled"
+        app:itemIconSize="@dimen/bottom_nav_icon_size"
+        app:labelVisibilityMode="unlabeled"
         app:itemHorizontalTranslationEnabled="false"
         app:menu="@menu/menu_bottom_nav" />
+
+    <include layout="@layout/bottom_nav_labels" />
 </LinearLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="bottom_nav_height">96dp</dimen>
+    <dimen name="bottom_nav_icon_size">48dp</dimen>
+</resources>


### PR DESCRIPTION
## Summary
- bump bottom navigation size using new dimension resources
- reference new sizes in all bottom navigation layouts
- hide labels inside the bottom bar and add a row of labels below

## Testing
- `./gradlew help`
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68571d9841008332926da6e1df1da79f