### PR TITLE
Adjust bottom nav height

### DIFF
--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="bottom_nav_height">96dp</dimen>
+    <!-- Reduced height so labels appear just below the icons without excessive spacing -->
+    <dimen name="bottom_nav_height">56dp</dimen>
     <dimen name="bottom_nav_icon_size">48dp</dimen>
 </resources>


### PR DESCRIPTION
## Summary
- shrink bottom navigation bar so labels sit right under icons

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857243635d88332ae8e8e71222fbfdc