### PR TITLE
Lower bottom nav icons

### DIFF
--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -46,7 +46,7 @@
         android:layout_width="match_parent"
         android:layout_height="@dimen/bottom_nav_height"
         android:background="@color/background_light"
-        android:paddingTop="4dp"
+        android:paddingTop="20dp"
         android:paddingBottom="4dp"
         app:itemIconSize="@dimen/bottom_nav_icon_size"
         app:labelVisibilityMode="unlabeled"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -28,7 +28,7 @@
         android:layout_width="match_parent"
         android:layout_height="@dimen/bottom_nav_height"
         android:background="@color/background_light"
-        android:paddingTop="4dp"
+        android:paddingTop="20dp"
         android:paddingBottom="4dp"
         app:itemIconSize="@dimen/bottom_nav_icon_size"
         app:labelVisibilityMode="unlabeled"

--- a/app/src/main/res/layout/fragment_course.xml
+++ b/app/src/main/res/layout/fragment_course.xml
@@ -526,7 +526,7 @@
         android:layout_width="match_parent"
         android:layout_height="@dimen/bottom_nav_height"
         android:background="@color/background_light"
-        android:paddingTop="4dp"
+        android:paddingTop="20dp"
         android:paddingBottom="4dp"
         app:itemIconSize="@dimen/bottom_nav_icon_size"
         app:labelVisibilityMode="unlabeled"

--- a/app/src/main/res/layout/fragment_stamp.xml
+++ b/app/src/main/res/layout/fragment_stamp.xml
@@ -45,7 +45,7 @@
         android:layout_width="match_parent"
         android:layout_height="@dimen/bottom_nav_height"
         android:background="@color/background_light"
-        android:paddingTop="4dp"
+        android:paddingTop="20dp"
         android:paddingBottom="4dp"
         app:itemIconSize="@dimen/bottom_nav_icon_size"
         app:labelVisibilityMode="unlabeled"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <!-- Reduced height so labels appear just below the icons without excessive spacing -->
-    <dimen name="bottom_nav_height">56dp</dimen>
+    <!-- Increased height and icon offset so icons start lower inside the bar -->
+    <dimen name="bottom_nav_height">72dp</dimen>
     <dimen name="bottom_nav_icon_size">48dp</dimen>
 </resources>


### PR DESCRIPTION
## Summary
- bump bottom nav bar height so icons start lower
- update padding for bottom nav across layouts

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857260353e083328c07db3446f75263