### PR TITLE
Persist chat history for logged-in users

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/data/AuthRepository.kt
+++ b/app/src/main/java/com/pnu/pnuguide/data/AuthRepository.kt
@@ -2,9 +2,14 @@ package com.pnu.pnuguide.data
 
 import com.google.firebase.auth.FirebaseAuth
 import com.google.android.gms.tasks.Task
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.suspendCancellableCoroutine
+
+import com.pnu.pnuguide.data.ChatRepository
 
 object AuthRepository {
     private val auth: FirebaseAuth = FirebaseAuth.getInstance()
@@ -27,8 +32,14 @@ object AuthRepository {
     }
 
     fun signOut() {
+        val currentUid = uid
         auth.signOut()
         uid = null
+        currentUid?.let { u ->
+            CoroutineScope(Dispatchers.IO).launch {
+                ChatRepository.clearMessages(u)
+            }
+        }
     }
 
     fun currentUser() = auth.currentUser

--- a/app/src/main/java/com/pnu/pnuguide/data/ChatRepository.kt
+++ b/app/src/main/java/com/pnu/pnuguide/data/ChatRepository.kt
@@ -1,0 +1,41 @@
+package com.pnu.pnuguide.data
+
+import com.google.android.gms.tasks.Task
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ktx.firestoreSettings
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.suspendCancellableCoroutine
+import com.pnu.pnuguide.ui.chat.ChatUiMessage
+
+object ChatRepository {
+    private val firestore = FirebaseFirestore.getInstance().apply {
+        firestoreSettings = firestoreSettings { isPersistenceEnabled = true }
+    }
+
+    suspend fun loadMessages(uid: String): List<ChatUiMessage> {
+        val snapshot = firestore.collection("chats").document(uid).get().await()
+        val list = snapshot.get("messages") as? List<Map<String, Any>> ?: return emptyList()
+        return list.map {
+            val content = it["content"] as? String ?: ""
+            val isUser = it["isUser"] as? Boolean ?: false
+            ChatUiMessage(content, isUser)
+        }
+    }
+
+    suspend fun saveMessages(uid: String, messages: List<ChatUiMessage>) {
+        val list = messages.map { mapOf("content" to it.content, "isUser" to it.isUser) }
+        firestore.collection("chats").document(uid)
+            .set(mapOf("messages" to list))
+            .await()
+    }
+
+    suspend fun clearMessages(uid: String) {
+        firestore.collection("chats").document(uid).delete().await()
+    }
+}
+
+private suspend fun <T> Task<T>.await(): T = suspendCancellableCoroutine { cont ->
+    addOnSuccessListener { cont.resume(it) }
+    addOnFailureListener { cont.resumeWithException(it) }
+}


### PR DESCRIPTION
## Summary
- store chat messages per user in Firestore via `ChatRepository`
- load and persist messages in `ChatViewModel`
- clear stored messages on logout

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857bc5028b483329c8f991d31093d1a