### PR TITLE
Fix chat history persistence

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/data/ChatLocalStore.kt
+++ b/app/src/main/java/com/pnu/pnuguide/data/ChatLocalStore.kt
@@ -1,0 +1,29 @@
+package com.pnu.pnuguide.data
+
+import android.content.Context
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.pnu.pnuguide.ui.chat.ChatUiMessage
+
+object ChatLocalStore {
+    private const val PREF_NAME = "chat_local"
+    private const val KEY_MESSAGES = "messages"
+
+    private fun prefs(context: Context) =
+        context.getSharedPreferences(PREF_NAME, 0)
+
+    fun loadMessages(context: Context): List<ChatUiMessage> {
+        val json = prefs(context).getString(KEY_MESSAGES, null) ?: return emptyList()
+        val type = object : TypeToken<List<ChatUiMessage>>() {}.type
+        return Gson().fromJson(json, type)
+    }
+
+    fun saveMessages(context: Context, messages: List<ChatUiMessage>) {
+        val json = Gson().toJson(messages)
+        prefs(context).edit().putString(KEY_MESSAGES, json).apply()
+    }
+
+    fun clear(context: Context) {
+        prefs(context).edit().clear().apply()
+    }
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/ChatActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/ChatActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.widget.Button
 import android.widget.EditText
 import androidx.activity.viewModels
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -25,7 +26,9 @@ import kotlinx.coroutines.flow.collectLatest
 
 class ChatActivity : AppCompatActivity() {
 
-    private val viewModel by viewModels<ChatViewModel>()
+    private val viewModel by viewModels<ChatViewModel> {
+        AndroidViewModelFactory.getInstance(application)
+    }
     private lateinit var adapter: ChatAdapter
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/pnu/pnuguide/ui/ChatFragment.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/ChatFragment.kt
@@ -8,6 +8,7 @@ import android.widget.Button
 import android.widget.EditText
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -16,7 +17,9 @@ import kotlinx.coroutines.flow.collectLatest
 
 class ChatFragment : Fragment() {
 
-    private val viewModel by viewModels<ChatViewModel>()
+    private val viewModel by viewModels<ChatViewModel> {
+        AndroidViewModelFactory.getInstance(requireActivity().application)
+    }
     private lateinit var adapter: ChatAdapter
 
     override fun onCreateView(

--- a/app/src/test/java/com/pnu/pnuguide/ChatViewModelTest.kt
+++ b/app/src/test/java/com/pnu/pnuguide/ChatViewModelTest.kt
@@ -1,5 +1,7 @@
 package com.pnu.pnuguide
 
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
 import com.pnu.pnuguide.ui.chat.ChatViewModel
 import org.junit.Assert.assertNotNull
 import org.junit.Test
@@ -7,7 +9,8 @@ import org.junit.Test
 class ChatViewModelTest {
     @Test
     fun viewModel_initializes() {
-        val vm = ChatViewModel()
+        val app = ApplicationProvider.getApplicationContext<Application>()
+        val vm = ChatViewModel(app)
         assertNotNull(vm)
     }
 }


### PR DESCRIPTION
## Summary
- persist chat messages locally via `ChatLocalStore`
- initialize `ChatViewModel` with saved messages and update on change
- update `ChatActivity` and `ChatFragment` to use the new AndroidViewModel
- fix unit test to use application context

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857c0862b348332a668da98d671c632