### PR TITLE
Fix header setup type mismatch

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/ui/HeaderUtils.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/HeaderUtils.kt
@@ -37,6 +37,34 @@ fun MaterialToolbar.setupHeader1(activity: AppCompatActivity, titleResId: Int) {
     }
 }
 
+fun MaterialToolbar.setupHeader1(activity: AppCompatActivity, title: String) {
+    activity.setSupportActionBar(this)
+    this.title = title
+    this.navigationIcon = ContextCompat.getDrawable(activity, R.drawable.ic_map)
+    this.setNavigationOnClickListener {
+        activity.startActivity(Intent(activity, MapActivity::class.java))
+    }
+
+    // 메뉴 인플레이트
+    this.inflateMenu(R.menu.menu_home_toolbar)
+
+    // 아이콘을 벡터 자산으로 교체
+    menu.findItem(R.id.action_settings)?.apply {
+        icon = ContextCompat.getDrawable(context, R.drawable.ic_settings)
+        setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
+    }
+
+    // 클릭 리스너
+    this.setOnMenuItemClickListener { item ->
+        if (item.itemId == R.id.action_settings) {
+            activity.startActivity(Intent(activity, SettingsActivity::class.java))
+            true
+        } else {
+            false
+        }
+    }
+}
+
 fun MaterialToolbar.setupHeaderSettings(activity: AppCompatActivity, titleResId: Int) {
     activity.setSupportActionBar(this)
     this.title = activity.getString(titleResId)


### PR DESCRIPTION
## Summary
- add overloaded header setup that accepts a string
- reuse it in QuizActivity when a title string is supplied

## Testing
- `./gradlew test` *(fails: Gradle daemon started but build didn't finish)*

------
https://chatgpt.com/codex/tasks/task_e_6857d42cc0fc833292dfd67d6ecf78c7