### PR TITLE
Add quiz progress and first quiz

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/data/CourseData.kt
+++ b/app/src/main/java/com/pnu/pnuguide/data/CourseData.kt
@@ -2,7 +2,7 @@ package com.pnu.pnuguide.data
 
 object CourseData {
     fun loadStamps(): List<Stamp> {
-        return List(27) { index ->
+        return List(24) { index ->
             Stamp(id = "spot${index + 1}", name = "Spot ${index + 1}")
         }
     }

--- a/app/src/main/java/com/pnu/pnuguide/data/QuizProgress.kt
+++ b/app/src/main/java/com/pnu/pnuguide/data/QuizProgress.kt
@@ -1,0 +1,24 @@
+package com.pnu.pnuguide.data
+
+import android.content.Context
+
+object QuizProgress {
+    private const val PREF_NAME = "quiz_progress"
+    private const val KEY_COUNT = "count"
+
+    private fun prefs(context: Context) =
+        context.getSharedPreferences(PREF_NAME, 0)
+
+    fun getCount(context: Context): Int = prefs(context).getInt(KEY_COUNT, 0)
+
+    fun isSolved(context: Context, id: String): Boolean =
+        prefs(context).getBoolean(id, false)
+
+    fun markSolved(context: Context, id: String) {
+        val p = prefs(context)
+        if (!p.getBoolean(id, false)) {
+            val count = p.getInt(KEY_COUNT, 0) + 1
+            p.edit().putBoolean(id, true).putInt(KEY_COUNT, count).apply()
+        }
+    }
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/HomeFragment.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/HomeFragment.kt
@@ -8,6 +8,9 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import com.google.android.material.button.MaterialButton
 import com.pnu.pnuguide.R
+import android.widget.TextView
+import android.widget.ProgressBar
+import com.pnu.pnuguide.data.QuizProgress
 import com.pnu.pnuguide.ui.course.CourseActivity
 import com.pnu.pnuguide.ui.stamp.StampActivity
 
@@ -28,5 +31,12 @@ class HomeFragment : Fragment() {
         view.findViewById<MaterialButton>(R.id.btn_view_favorites).setOnClickListener {
             startActivity(Intent(requireContext(), CourseActivity::class.java))
         }
+
+        val count = QuizProgress.getCount(requireContext())
+        val progressText = view.findViewById<TextView>(R.id.tv_stamp_progress)
+        val progressBar = view.findViewById<ProgressBar>(R.id.progress_stamp)
+        progressText.text = "Stamps Collected: ${'$'}count/24"
+        progressBar.max = 24
+        progressBar.progress = count
     }
 }

--- a/app/src/main/java/com/pnu/pnuguide/ui/quiz/QuizActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/quiz/QuizActivity.kt
@@ -10,6 +10,9 @@ import com.pnu.pnuguide.ui.setupHeader1
 import android.view.Menu
 import android.view.MenuItem
 import androidx.core.content.ContextCompat
+import android.widget.Toast
+import com.google.android.material.button.MaterialButton
+import com.pnu.pnuguide.data.QuizProgress
 
 class QuizActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -25,6 +28,19 @@ class QuizActivity : AppCompatActivity() {
             toolbar.setupHeader1(this, R.string.title_quiz)
         }
         toolbar.setNavigationOnClickListener { finish() }
+
+        if (layoutRes == R.layout.activity_quiz_1) {
+            val btnO = findViewById<MaterialButton>(R.id.btn_option_o)
+            val btnX = findViewById<MaterialButton>(R.id.btn_option_x)
+            btnO.setOnClickListener {
+                QuizProgress.markSolved(this, "quiz1")
+                Toast.makeText(this, "정답입니다!", Toast.LENGTH_SHORT).show()
+                finish()
+            }
+            btnX.setOnClickListener {
+                Toast.makeText(this, "오답입니다", Toast.LENGTH_SHORT).show()
+            }
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/app/src/main/res/layout/activity_quiz_1.xml
+++ b/app/src/main/res/layout/activity_quiz_1.xml
@@ -19,11 +19,37 @@
         android:id="@+id/text_quiz_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Quiz"
+        android:text="Quiz 1"
         android:textSize="18sp"
         android:textStyle="bold"
         android:padding="16dp" />
 
-    <!-- TODO: Add quiz content for 대학본부 -->
+    <TextView
+        android:id="@+id/text_question"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="대학본부의 건물번호는 205이다."/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_o"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="O" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_x"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="X" />
+    </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
## Summary
- implement quiz progress storage
- build first quiz page with O/X buttons
- track progress in HomeFragment
- limit total stamps to 24

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857d773c0ac83328382eb263071bcff