### PR TITLE
Implement quiz 2 screen

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/ui/quiz/QuizActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/quiz/QuizActivity.kt
@@ -40,6 +40,17 @@ class QuizActivity : AppCompatActivity() {
             btnX.setOnClickListener {
                 Toast.makeText(this, "오답입니다", Toast.LENGTH_SHORT).show()
             }
+        } else if (layoutRes == R.layout.activity_quiz_2) {
+            val btnO = findViewById<MaterialButton>(R.id.btn_option_o)
+            val btnX = findViewById<MaterialButton>(R.id.btn_option_x)
+            btnX.setOnClickListener {
+                QuizProgress.markSolved(this, "quiz2")
+                Toast.makeText(this, "정답입니다!", Toast.LENGTH_SHORT).show()
+                finish()
+            }
+            btnO.setOnClickListener {
+                Toast.makeText(this, "오답입니다", Toast.LENGTH_SHORT).show()
+            }
         }
     }
 

--- a/app/src/main/res/layout/activity_quiz_2.xml
+++ b/app/src/main/res/layout/activity_quiz_2.xml
@@ -19,11 +19,37 @@
         android:id="@+id/text_quiz_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Quiz"
+        android:text="Quiz 2"
         android:textSize="18sp"
         android:textStyle="bold"
         android:padding="16dp" />
 
-    <!-- TODO: Add quiz content for 조각공원 -->
+    <TextView
+        android:id="@+id/text_question"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="조각공원은 2010년에 처음 조성되었다." />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_o"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="O" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_x"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="X" />
+    </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
## Summary
- build quiz 2 layout with O/X buttons and question
- handle quiz 2 answer logic in `QuizActivity`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857dd2bb6248332a4066994e2909790