### PR TITLE
Add quiz screens 10-16

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/ui/quiz/QuizActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/quiz/QuizActivity.kt
@@ -128,6 +128,83 @@ class QuizActivity : AppCompatActivity() {
             btnO.setOnClickListener {
                 Toast.makeText(this, "오답입니다", Toast.LENGTH_SHORT).show()
             }
+        } else if (layoutRes == R.layout.activity_quiz_10) {
+            val btnO = findViewById<MaterialButton>(R.id.btn_option_o)
+            val btnX = findViewById<MaterialButton>(R.id.btn_option_x)
+            btnX.setOnClickListener {
+                QuizProgress.markSolved(this, "quiz10")
+                Toast.makeText(this, "정답입니다!", Toast.LENGTH_SHORT).show()
+                finish()
+            }
+            btnO.setOnClickListener {
+                Toast.makeText(this, "오답입니다", Toast.LENGTH_SHORT).show()
+            }
+        } else if (layoutRes == R.layout.activity_quiz_11) {
+            val btnO = findViewById<MaterialButton>(R.id.btn_option_o)
+            val btnX = findViewById<MaterialButton>(R.id.btn_option_x)
+            btnO.setOnClickListener {
+                QuizProgress.markSolved(this, "quiz11")
+                Toast.makeText(this, "정답입니다!", Toast.LENGTH_SHORT).show()
+                finish()
+            }
+            btnX.setOnClickListener {
+                Toast.makeText(this, "오답입니다", Toast.LENGTH_SHORT).show()
+            }
+        } else if (layoutRes == R.layout.activity_quiz_12) {
+            val btnO = findViewById<MaterialButton>(R.id.btn_option_o)
+            val btnX = findViewById<MaterialButton>(R.id.btn_option_x)
+            btnO.setOnClickListener {
+                QuizProgress.markSolved(this, "quiz12")
+                Toast.makeText(this, "정답입니다!", Toast.LENGTH_SHORT).show()
+                finish()
+            }
+            btnX.setOnClickListener {
+                Toast.makeText(this, "오답입니다", Toast.LENGTH_SHORT).show()
+            }
+        } else if (layoutRes == R.layout.activity_quiz_13) {
+            val btnO = findViewById<MaterialButton>(R.id.btn_option_o)
+            val btnX = findViewById<MaterialButton>(R.id.btn_option_x)
+            btnX.setOnClickListener {
+                QuizProgress.markSolved(this, "quiz13")
+                Toast.makeText(this, "정답입니다!", Toast.LENGTH_SHORT).show()
+                finish()
+            }
+            btnO.setOnClickListener {
+                Toast.makeText(this, "오답입니다", Toast.LENGTH_SHORT).show()
+            }
+        } else if (layoutRes == R.layout.activity_quiz_14) {
+            val btnO = findViewById<MaterialButton>(R.id.btn_option_o)
+            val btnX = findViewById<MaterialButton>(R.id.btn_option_x)
+            btnX.setOnClickListener {
+                QuizProgress.markSolved(this, "quiz14")
+                Toast.makeText(this, "정답입니다!", Toast.LENGTH_SHORT).show()
+                finish()
+            }
+            btnO.setOnClickListener {
+                Toast.makeText(this, "오답입니다", Toast.LENGTH_SHORT).show()
+            }
+        } else if (layoutRes == R.layout.activity_quiz_15) {
+            val btnO = findViewById<MaterialButton>(R.id.btn_option_o)
+            val btnX = findViewById<MaterialButton>(R.id.btn_option_x)
+            btnX.setOnClickListener {
+                QuizProgress.markSolved(this, "quiz15")
+                Toast.makeText(this, "정답입니다!", Toast.LENGTH_SHORT).show()
+                finish()
+            }
+            btnO.setOnClickListener {
+                Toast.makeText(this, "오답입니다", Toast.LENGTH_SHORT).show()
+            }
+        } else if (layoutRes == R.layout.activity_quiz_16) {
+            val btnO = findViewById<MaterialButton>(R.id.btn_option_o)
+            val btnX = findViewById<MaterialButton>(R.id.btn_option_x)
+            btnX.setOnClickListener {
+                QuizProgress.markSolved(this, "quiz16")
+                Toast.makeText(this, "정답입니다!", Toast.LENGTH_SHORT).show()
+                finish()
+            }
+            btnO.setOnClickListener {
+                Toast.makeText(this, "오답입니다", Toast.LENGTH_SHORT).show()
+            }
         }
     }
 

--- a/app/src/main/res/layout/activity_quiz_10.xml
+++ b/app/src/main/res/layout/activity_quiz_10.xml
@@ -19,11 +19,37 @@
         android:id="@+id/text_quiz_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Quiz"
+        android:text="Quiz 10"
         android:textSize="18sp"
         android:textStyle="bold"
         android:padding="16dp" />
 
-    <!-- TODO: Add quiz content for 학생회관 식당 -->
+    <TextView
+        android:id="@+id/text_question"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="학생회관 식당은 주말에도 항상 운영된다." />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_o"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="O" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_x"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="X" />
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_quiz_11.xml
+++ b/app/src/main/res/layout/activity_quiz_11.xml
@@ -19,11 +19,37 @@
         android:id="@+id/text_quiz_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Quiz"
+        android:text="Quiz 11"
         android:textSize="18sp"
         android:textStyle="bold"
         android:padding="16dp" />
 
-    <!-- TODO: Add quiz content for 경암체육관 -->
+    <TextView
+        android:id="@+id/text_question"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="경암체육관은 일반 학생들도 자유롭게 이용할 수 있다." />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_o"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="O" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_x"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="X" />
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_quiz_12.xml
+++ b/app/src/main/res/layout/activity_quiz_12.xml
@@ -19,11 +19,37 @@
         android:id="@+id/text_quiz_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Quiz"
+        android:text="Quiz 12"
         android:textSize="18sp"
         android:textStyle="bold"
         android:padding="16dp" />
 
-    <!-- TODO: Add quiz content for 약학관 -->
+    <TextView
+        android:id="@+id/text_question"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="약학관에는 실제 약국처럼 구성된 실습실이 존재한다." />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_o"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="O" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_x"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="X" />
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_quiz_13.xml
+++ b/app/src/main/res/layout/activity_quiz_13.xml
@@ -19,11 +19,37 @@
         android:id="@+id/text_quiz_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Quiz"
+        android:text="Quiz 13"
         android:textSize="18sp"
         android:textStyle="bold"
         android:padding="16dp" />
 
-    <!-- TODO: Add quiz content for 지질박물관 -->
+    <TextView
+        android:id="@+id/text_question"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="지질박물관은 부산대학교 학생만 입장할 수 있다." />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_o"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="O" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_x"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="X" />
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_quiz_14.xml
+++ b/app/src/main/res/layout/activity_quiz_14.xml
@@ -19,11 +19,37 @@
         android:id="@+id/text_quiz_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Quiz"
+        android:text="Quiz 14"
         android:textSize="18sp"
         android:textStyle="bold"
         android:padding="16dp" />
 
-    <!-- TODO: Add quiz content for 샛벌회관 식당 -->
+    <TextView
+        android:id="@+id/text_question"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="샛벌회관 식당은 뷔페식 식단을 제공한다." />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_o"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="O" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_x"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="X" />
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_quiz_15.xml
+++ b/app/src/main/res/layout/activity_quiz_15.xml
@@ -19,11 +19,37 @@
         android:id="@+id/text_quiz_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Quiz"
+        android:text="Quiz 15"
         android:textSize="18sp"
         android:textStyle="bold"
         android:padding="16dp" />
 
-    <!-- TODO: Add quiz content for 박물관 -->
+    <TextView
+        android:id="@+id/text_question"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="부산대 박물관은 우리나라 국립 박물관에 소속되어 있다." />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_o"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="O" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_x"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="X" />
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_quiz_16.xml
+++ b/app/src/main/res/layout/activity_quiz_16.xml
@@ -19,11 +19,37 @@
         android:id="@+id/text_quiz_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Quiz"
+        android:text="Quiz 16"
         android:textSize="18sp"
         android:textStyle="bold"
         android:padding="16dp" />
 
-    <!-- TODO: Add quiz content for 10.16기념관 -->
+    <TextView
+        android:id="@+id/text_question"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="10.16 기념관은 부산대학교 개교 기념일을 기념하기 위한 공간이다." />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_o"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="O" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_x"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="X" />
+    </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
## Summary
- implement layouts for quizzes 10–16
- wire up answers in `QuizActivity` to track stamp progress

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857e4faee888332b638c636c704c71b