### PR TITLE
Add quiz screens 17-24 with stamp tracking

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,14 @@
         <activity android:name="com.pnu.pnuguide.ui.course.SpotListActivity" />
         <activity android:name="com.pnu.pnuguide.ui.course.SpotDetailActivity" />
         <activity android:name="com.pnu.pnuguide.ui.SettingsActivity" />
+        <activity android:name="com.pnu.pnuguide.ui.quiz.Quiz17Activity" />
+        <activity android:name="com.pnu.pnuguide.ui.quiz.Quiz18Activity" />
+        <activity android:name="com.pnu.pnuguide.ui.quiz.Quiz19Activity" />
+        <activity android:name="com.pnu.pnuguide.ui.quiz.Quiz20Activity" />
+        <activity android:name="com.pnu.pnuguide.ui.quiz.Quiz21Activity" />
+        <activity android:name="com.pnu.pnuguide.ui.quiz.Quiz22Activity" />
+        <activity android:name="com.pnu.pnuguide.ui.quiz.Quiz23Activity" />
+        <activity android:name="com.pnu.pnuguide.ui.quiz.Quiz24Activity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/pnu/pnuguide/data/StampProgress.kt
+++ b/app/src/main/java/com/pnu/pnuguide/data/StampProgress.kt
@@ -1,0 +1,20 @@
+package com.pnu.pnuguide.data
+
+import android.content.Context
+
+object StampProgress {
+    private const val PREF_NAME = "stamps"
+    private const val KEY_COUNT = "count"
+    const val MAX = 24
+
+    fun getProgress(context: Context): Int {
+        val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+        return prefs.getInt(KEY_COUNT, 0)
+    }
+
+    fun increment(context: Context) {
+        val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+        val current = prefs.getInt(KEY_COUNT, 0)
+        prefs.edit().putInt(KEY_COUNT, (current + 1).coerceAtMost(MAX)).apply()
+    }
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/HomeFragment.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/HomeFragment.kt
@@ -10,6 +10,8 @@ import com.google.android.material.button.MaterialButton
 import com.pnu.pnuguide.R
 import com.pnu.pnuguide.ui.course.CourseActivity
 import com.pnu.pnuguide.ui.stamp.StampActivity
+import android.widget.TextView
+import com.pnu.pnuguide.data.StampProgress
 
 class HomeFragment : Fragment() {
     override fun onCreateView(
@@ -28,5 +30,12 @@ class HomeFragment : Fragment() {
         view.findViewById<MaterialButton>(R.id.btn_stamp).setOnClickListener {
             startActivity(Intent(requireContext(), StampActivity::class.java))
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val progress = StampProgress.getProgress(requireContext())
+        view?.findViewById<TextView>(R.id.text_stamp_progress)?.text =
+            getString(R.string.stamp_progress_format, progress, StampProgress.MAX)
     }
 }

--- a/app/src/main/java/com/pnu/pnuguide/ui/quiz/Quiz17Activity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/quiz/Quiz17Activity.kt
@@ -1,0 +1,6 @@
+package com.pnu.pnuguide.ui.quiz
+
+class Quiz17Activity : QuizActivity() {
+    override val question = "건설관에서는 건축학과 수업이 열린다."
+    override val answer = true
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/quiz/Quiz18Activity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/quiz/Quiz18Activity.kt
@@ -1,0 +1,6 @@
+package com.pnu.pnuguide.ui.quiz
+
+class Quiz18Activity : QuizActivity() {
+    override val question = "V-SPACE는 인문대 학생 전용 공간이다."
+    override val answer = false
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/quiz/Quiz19Activity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/quiz/Quiz19Activity.kt
@@ -1,0 +1,6 @@
+package com.pnu.pnuguide.ui.quiz
+
+class Quiz19Activity : QuizActivity() {
+    override val question = "진리의 뜰은 학생들이 야외에서 휴식을 즐기는 장소로 인기다."
+    override val answer = true
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/quiz/Quiz20Activity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/quiz/Quiz20Activity.kt
@@ -1,0 +1,6 @@
+package com.pnu.pnuguide.ui.quiz
+
+class Quiz20Activity : QuizActivity() {
+    override val question = "인문관은 자연과학대학 소속 건물이다."
+    override val answer = false
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/quiz/Quiz21Activity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/quiz/Quiz21Activity.kt
@@ -1,0 +1,6 @@
+package com.pnu.pnuguide.ui.quiz
+
+class Quiz21Activity : QuizActivity() {
+    override val question = "넉넉한 터는 부산대학교의 주차 공간 중 하나다."
+    override val answer = false
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/quiz/Quiz22Activity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/quiz/Quiz22Activity.kt
@@ -1,0 +1,6 @@
+package com.pnu.pnuguide.ui.quiz
+
+class Quiz22Activity : QuizActivity() {
+    override val question = "시월 광장은 10월 학생축제와 관련된 의미가 있다."
+    override val answer = true
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/quiz/Quiz23Activity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/quiz/Quiz23Activity.kt
@@ -1,0 +1,6 @@
+package com.pnu.pnuguide.ui.quiz
+
+class Quiz23Activity : QuizActivity() {
+    override val question = "민주 언덕은 1980년대 학생운동을 기념하는 공간이다."
+    override val answer = true
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/quiz/Quiz24Activity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/quiz/Quiz24Activity.kt
@@ -1,0 +1,6 @@
+package com.pnu.pnuguide.ui.quiz
+
+class Quiz24Activity : QuizActivity() {
+    override val question = "미리내 골은 밤하늘이 잘 보이는 언덕길이라는 뜻이다."
+    override val answer = true
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/quiz/QuizActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/quiz/QuizActivity.kt
@@ -1,0 +1,57 @@
+package com.pnu.pnuguide.ui.quiz
+
+import android.os.Bundle
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.button.MaterialButton
+import com.pnu.pnuguide.R
+import com.pnu.pnuguide.data.StampProgress
+import com.pnu.pnuguide.ui.SettingsActivity
+
+open class QuizActivity : AppCompatActivity() {
+
+    open val question: String = ""
+    open val answer: Boolean = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_quiz)
+
+        val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_quiz)
+        setSupportActionBar(toolbar)
+        toolbar.inflateMenu(R.menu.menu_home_toolbar)
+        toolbar.setNavigationOnClickListener {
+            startActivity(android.content.Intent(this, com.pnu.pnuguide.ui.map.MapActivity::class.java))
+        }
+        toolbar.setOnMenuItemClickListener { item ->
+            if (item.itemId == R.id.action_settings) {
+                startActivity(android.content.Intent(this, SettingsActivity::class.java))
+                true
+            } else {
+                false
+            }
+        }
+
+        findViewById<TextView>(R.id.text_question).text = question
+
+        findViewById<MaterialButton>(R.id.button_o).setOnClickListener {
+            handleAnswer(true, answer)
+        }
+        findViewById<MaterialButton>(R.id.button_x).setOnClickListener {
+            handleAnswer(false, answer)
+        }
+    }
+
+    private fun handleAnswer(userAnswer: Boolean, correctAnswer: Boolean) {
+        if (userAnswer == correctAnswer) {
+            StampProgress.increment(this)
+            Toast.makeText(this, R.string.correct_answer, Toast.LENGTH_SHORT).show()
+        } else {
+            Toast.makeText(this, R.string.wrong_answer, Toast.LENGTH_SHORT).show()
+        }
+        finish()
+    }
+
+}

--- a/app/src/main/res/layout/activity_quiz.xml
+++ b/app/src/main/res/layout/activity_quiz.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar_quiz"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        android:navigationIcon="@drawable/ic_map"
+        android:title="@string/title_quiz" />
+
+    <TextView
+        android:id="@+id/text_question"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="18sp"
+        android:paddingTop="24dp"
+        android:paddingBottom="24dp" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_o"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="O" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_x"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="X"
+        android:layout_marginTop="8dp" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -32,6 +32,14 @@
             app:backgroundTint="@color/primary"
             app:cornerRadius="8dp" />
 
+        <TextView
+            android:id="@+id/text_stamp_progress"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="8dp"
+            android:text="Stamp Progress: 0/24"
+            android:textStyle="bold" />
+
 
         <androidx.cardview.widget.CardView
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,4 +26,8 @@
     <string name="title_stamp">Stamp</string>
     <string name="title_chatbot">Chatbot</string>
     <string name="hint_search_map">Search location</string>
+    <string name="title_quiz">Quiz</string>
+    <string name="correct_answer">정답입니다!</string>
+    <string name="wrong_answer">틀렸습니다.</string>
+    <string name="stamp_progress_format">Stamp Progress: %1$d/%2$d</string>
 </resources>


### PR DESCRIPTION
## Summary
- implement `QuizActivity` base and specific activities for quizzes 17-24
- track stamp progress with new `StampProgress` helper
- show stamp progress on Home screen
- add layout for quiz activity and register activities in manifest

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857e6eadf7c8332a4641a424ff72f99