### PR TITLE
Add quiz screens for 17-24

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/ui/quiz/QuizActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/quiz/QuizActivity.kt
@@ -205,6 +205,94 @@ class QuizActivity : AppCompatActivity() {
             btnO.setOnClickListener {
                 Toast.makeText(this, "오답입니다", Toast.LENGTH_SHORT).show()
             }
+        } else if (layoutRes == R.layout.activity_quiz_17) {
+            val btnO = findViewById<MaterialButton>(R.id.btn_option_o)
+            val btnX = findViewById<MaterialButton>(R.id.btn_option_x)
+            btnO.setOnClickListener {
+                QuizProgress.markSolved(this, "quiz17")
+                Toast.makeText(this, "정답입니다!", Toast.LENGTH_SHORT).show()
+                finish()
+            }
+            btnX.setOnClickListener {
+                Toast.makeText(this, "오답입니다", Toast.LENGTH_SHORT).show()
+            }
+        } else if (layoutRes == R.layout.activity_quiz_18) {
+            val btnO = findViewById<MaterialButton>(R.id.btn_option_o)
+            val btnX = findViewById<MaterialButton>(R.id.btn_option_x)
+            btnX.setOnClickListener {
+                QuizProgress.markSolved(this, "quiz18")
+                Toast.makeText(this, "정답입니다!", Toast.LENGTH_SHORT).show()
+                finish()
+            }
+            btnO.setOnClickListener {
+                Toast.makeText(this, "오답입니다", Toast.LENGTH_SHORT).show()
+            }
+        } else if (layoutRes == R.layout.activity_quiz_19) {
+            val btnO = findViewById<MaterialButton>(R.id.btn_option_o)
+            val btnX = findViewById<MaterialButton>(R.id.btn_option_x)
+            btnO.setOnClickListener {
+                QuizProgress.markSolved(this, "quiz19")
+                Toast.makeText(this, "정답입니다!", Toast.LENGTH_SHORT).show()
+                finish()
+            }
+            btnX.setOnClickListener {
+                Toast.makeText(this, "오답입니다", Toast.LENGTH_SHORT).show()
+            }
+        } else if (layoutRes == R.layout.activity_quiz_20) {
+            val btnO = findViewById<MaterialButton>(R.id.btn_option_o)
+            val btnX = findViewById<MaterialButton>(R.id.btn_option_x)
+            btnX.setOnClickListener {
+                QuizProgress.markSolved(this, "quiz20")
+                Toast.makeText(this, "정답입니다!", Toast.LENGTH_SHORT).show()
+                finish()
+            }
+            btnO.setOnClickListener {
+                Toast.makeText(this, "오답입니다", Toast.LENGTH_SHORT).show()
+            }
+        } else if (layoutRes == R.layout.activity_quiz_21) {
+            val btnO = findViewById<MaterialButton>(R.id.btn_option_o)
+            val btnX = findViewById<MaterialButton>(R.id.btn_option_x)
+            btnX.setOnClickListener {
+                QuizProgress.markSolved(this, "quiz21")
+                Toast.makeText(this, "정답입니다!", Toast.LENGTH_SHORT).show()
+                finish()
+            }
+            btnO.setOnClickListener {
+                Toast.makeText(this, "오답입니다", Toast.LENGTH_SHORT).show()
+            }
+        } else if (layoutRes == R.layout.activity_quiz_22) {
+            val btnO = findViewById<MaterialButton>(R.id.btn_option_o)
+            val btnX = findViewById<MaterialButton>(R.id.btn_option_x)
+            btnO.setOnClickListener {
+                QuizProgress.markSolved(this, "quiz22")
+                Toast.makeText(this, "정답입니다!", Toast.LENGTH_SHORT).show()
+                finish()
+            }
+            btnX.setOnClickListener {
+                Toast.makeText(this, "오답입니다", Toast.LENGTH_SHORT).show()
+            }
+        } else if (layoutRes == R.layout.activity_quiz_23) {
+            val btnO = findViewById<MaterialButton>(R.id.btn_option_o)
+            val btnX = findViewById<MaterialButton>(R.id.btn_option_x)
+            btnO.setOnClickListener {
+                QuizProgress.markSolved(this, "quiz23")
+                Toast.makeText(this, "정답입니다!", Toast.LENGTH_SHORT).show()
+                finish()
+            }
+            btnX.setOnClickListener {
+                Toast.makeText(this, "오답입니다", Toast.LENGTH_SHORT).show()
+            }
+        } else if (layoutRes == R.layout.activity_quiz_24) {
+            val btnO = findViewById<MaterialButton>(R.id.btn_option_o)
+            val btnX = findViewById<MaterialButton>(R.id.btn_option_x)
+            btnO.setOnClickListener {
+                QuizProgress.markSolved(this, "quiz24")
+                Toast.makeText(this, "정답입니다!", Toast.LENGTH_SHORT).show()
+                finish()
+            }
+            btnX.setOnClickListener {
+                Toast.makeText(this, "오답입니다", Toast.LENGTH_SHORT).show()
+            }
         }
     }
 

--- a/app/src/main/res/layout/activity_quiz_17.xml
+++ b/app/src/main/res/layout/activity_quiz_17.xml
@@ -19,11 +19,37 @@
         android:id="@+id/text_quiz_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Quiz"
+        android:text="Quiz 17"
         android:textSize="18sp"
         android:textStyle="bold"
         android:padding="16dp" />
 
-    <!-- TODO: Add quiz content for 건설관 -->
+    <TextView
+        android:id="@+id/text_question"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="건설관에서는 건축학과 수업이 열린다." />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_o"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="O" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_x"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="X" />
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_quiz_18.xml
+++ b/app/src/main/res/layout/activity_quiz_18.xml
@@ -19,11 +19,37 @@
         android:id="@+id/text_quiz_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Quiz"
+        android:text="Quiz 18"
         android:textSize="18sp"
         android:textStyle="bold"
         android:padding="16dp" />
 
-    <!-- TODO: Add quiz content for 기계관 V-SPACE -->
+    <TextView
+        android:id="@+id/text_question"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="V-SPACE는 인문대 학생 전용 공간이다." />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_o"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="O" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_x"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="X" />
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_quiz_19.xml
+++ b/app/src/main/res/layout/activity_quiz_19.xml
@@ -19,11 +19,37 @@
         android:id="@+id/text_quiz_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Quiz"
+        android:text="Quiz 19"
         android:textSize="18sp"
         android:textStyle="bold"
         android:padding="16dp" />
 
-    <!-- TODO: Add quiz content for 진리의 뜰 -->
+    <TextView
+        android:id="@+id/text_question"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="진리의 뜰은 학생들이 야외에서 휴식을 즐기는 장소로 인기다." />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_o"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="O" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_x"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="X" />
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_quiz_20.xml
+++ b/app/src/main/res/layout/activity_quiz_20.xml
@@ -19,11 +19,37 @@
         android:id="@+id/text_quiz_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Quiz"
+        android:text="Quiz 20"
         android:textSize="18sp"
         android:textStyle="bold"
         android:padding="16dp" />
 
-    <!-- TODO: Add quiz content for 인문관 -->
+    <TextView
+        android:id="@+id/text_question"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="인문관은 자연과학대학 소속 건물이다." />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_o"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="O" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_x"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="X" />
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_quiz_21.xml
+++ b/app/src/main/res/layout/activity_quiz_21.xml
@@ -19,11 +19,37 @@
         android:id="@+id/text_quiz_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Quiz"
+        android:text="Quiz 21"
         android:textSize="18sp"
         android:textStyle="bold"
         android:padding="16dp" />
 
-    <!-- TODO: Add quiz content for 넉넉한 터 -->
+    <TextView
+        android:id="@+id/text_question"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="넉넉한 터는 부산대학교의 주차 공간 중 하나다." />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_o"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="O" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_x"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="X" />
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_quiz_22.xml
+++ b/app/src/main/res/layout/activity_quiz_22.xml
@@ -19,11 +19,37 @@
         android:id="@+id/text_quiz_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Quiz"
+        android:text="Quiz 22"
         android:textSize="18sp"
         android:textStyle="bold"
         android:padding="16dp" />
 
-    <!-- TODO: Add quiz content for 시월 광장 -->
+    <TextView
+        android:id="@+id/text_question"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="시월 광장은 10월 학생축제와 관련된 의미가 있다." />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_o"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="O" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_x"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="X" />
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_quiz_23.xml
+++ b/app/src/main/res/layout/activity_quiz_23.xml
@@ -19,11 +19,37 @@
         android:id="@+id/text_quiz_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Quiz"
+        android:text="Quiz 23"
         android:textSize="18sp"
         android:textStyle="bold"
         android:padding="16dp" />
 
-    <!-- TODO: Add quiz content for 민주 언덕 -->
+    <TextView
+        android:id="@+id/text_question"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="민주 언덕은 1980년대 학생운동을 기념하는 공간이다." />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_o"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="O" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_x"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="X" />
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/activity_quiz_24.xml
+++ b/app/src/main/res/layout/activity_quiz_24.xml
@@ -19,11 +19,37 @@
         android:id="@+id/text_quiz_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Quiz"
+        android:text="Quiz 24"
         android:textSize="18sp"
         android:textStyle="bold"
         android:padding="16dp" />
 
-    <!-- TODO: Add quiz content for 미리내 골 -->
+    <TextView
+        android:id="@+id/text_question"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:text="미리내 골은 밤하늘이 잘 보이는 언덕길이라는 뜻이다." />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_o"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="O" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_option_x"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="X" />
+    </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
## Summary
- build out remaining quiz screens for #17–24
- wire them up to the QuizActivity logic
- keep stamp progress in HomeFragment

## Testing
- `./gradlew test` *(fails: Could not determine the dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6857e920ea088332b3dc01c27339eb01