### PR TITLE
Refine settings screen design

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/ui/SettingsActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/SettingsActivity.kt
@@ -27,8 +27,8 @@ class SettingsActivity : AppCompatActivity() {
         emailView.text = email ?: ""
 
 
-        setItem(R.id.item_account, R.drawable.ic_arrow_back_black_24, "Account Settings")
-        setItem(R.id.item_info, R.drawable.ic_arrow_back_black_24, "App Information")
+        setItem(R.id.item_account, R.drawable.ic_profile, "Account Settings")
+        setItem(R.id.item_info, android.R.drawable.ic_menu_info_details, "App Information")
     }
 
     private fun setItem(resId: Int, iconRes: Int, title: String) {

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -4,7 +4,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:background="@color/background_light">
+    android:background="@color/background_light"
+    android:padding="16dp">
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/toolbar_settings"
@@ -21,7 +22,7 @@
         android:layout_height="wrap_content"
         android:orientation="vertical"
         android:gravity="center_horizontal"
-        android:paddingTop="16dp">
+        android:paddingVertical="24dp">
 
         <ImageView
             android:layout_width="80dp"
@@ -47,14 +48,12 @@
             android:textSize="14sp" />
     </LinearLayout>
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1"
-        android:orientation="vertical">
+    <include
+        android:id="@+id/item_account"
+        layout="@layout/item_setting" />
 
-        <include layout="@layout/item_setting" android:id="@+id/item_account" />
-        <include layout="@layout/item_setting" android:id="@+id/item_info" />
-    </LinearLayout>
+    <include
+        android:id="@+id/item_info"
+        layout="@layout/item_setting" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/item_setting.xml
+++ b/app/src/main/res/layout/item_setting.xml
@@ -1,21 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/PNUGuide.Card"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:layout_marginBottom="12dp">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="56dp"
         android:orientation="horizontal"
+        android:gravity="center_vertical"
         android:paddingStart="16dp"
-        android:paddingEnd="16dp"
-        android:gravity="center_vertical">
+        android:paddingEnd="16dp">
 
         <ImageView
             android:id="@+id/icon"
             android:layout_width="24dp"
             android:layout_height="24dp"
+            android:tint="@color/primary"
             android:src="@android:drawable/ic_menu_manage" />
 
         <TextView
@@ -24,20 +26,9 @@
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:layout_marginStart="16dp"
+            android:text="Setting"
             android:textColor="@color/text_primary"
-            android:textSize="16sp"
-            android:text="Setting" />
-
-        <ImageView
-            android:layout_width="24dp"
-            android:layout_height="24dp"
-            android:src="@android:drawable/ic_menu_more" />
+            android:textSize="16sp" />
 
     </LinearLayout>
-
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/divider" />
-
-</LinearLayout>
+</com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
## Summary
- tidy up the settings layout with consistent margins
- simplify item_setting layout using MaterialCardView
- update icons used for each setting item

## Testing
- `./gradlew test --no-daemon --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68585a5021d08332bf2fab5c14ce4d39