### PR TITLE
Refine stamp screen UI

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampFragment.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/stamp/StampFragment.kt
@@ -58,6 +58,15 @@ class StampFragment : Fragment() {
             }
         }
 
+        binding.buttonCameraLarge.setOnClickListener {
+            if (ContextCompat.checkSelfPermission(requireContext(), Manifest.permission.CAMERA)
+                == PackageManager.PERMISSION_GRANTED) {
+                startCamera()
+            } else {
+                requestPermission.launch(Manifest.permission.CAMERA)
+            }
+        }
+
         viewModel.error.observe(viewLifecycleOwner) { failed ->
             if (failed) {
                 Toast.makeText(requireContext(), getString(com.pnu.pnuguide.R.string.stamp_failed), Toast.LENGTH_SHORT).show()

--- a/app/src/main/res/drawable/bg_camera_circle.xml
+++ b/app/src/main/res/drawable/bg_camera_circle.xml
@@ -1,0 +1,3 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval">
+    <solid android:color="@color/button_neutral" />
+</shape>

--- a/app/src/main/res/layout/fragment_stamp.xml
+++ b/app/src/main/res/layout/fragment_stamp.xml
@@ -21,6 +21,7 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/btn_download_pdf"
+        style="@style/PNUGuide.NeutralButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/download_map"
@@ -28,13 +29,27 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
+    <ImageButton
+        android:id="@+id/button_camera_large"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:layout_marginTop="24dp"
+        android:background="@drawable/bg_camera_circle"
+        android:padding="24dp"
+        android:src="@android:drawable/ic_menu_camera"
+        android:contentDescription="@string/action_camera"
+        app:layout_constraintTop_toBottomOf="@id/btn_download_pdf"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/button_start_camera"
+        style="@style/PNUGuide.NeutralButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/stamp_capture"
-        app:layout_constraintTop_toBottomOf="@id/btn_download_pdf"
+        app:layout_constraintTop_toBottomOf="@id/button_camera_large"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintBottom_toTopOf="@id/bottom_nav" />


### PR DESCRIPTION
## Summary
- redesign stamp screen to match home style
- add large camera button above the photo verification action
- use neutral button style for download and capture

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68586a77f4248332a1e766aa5523323a