### PR TITLE
Fix logout buttons and adjust chat spacing

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/ui/HeaderUtils.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/HeaderUtils.kt
@@ -8,6 +8,7 @@ import androidx.core.content.ContextCompat
 import com.pnu.pnuguide.R
 import com.pnu.pnuguide.ui.map.MapActivity
 import com.pnu.pnuguide.ui.SettingsActivity
+import com.pnu.pnuguide.ui.LoginActivity
 
 fun MaterialToolbar.setupHeader1(activity: AppCompatActivity, titleResId: Int) {
     activity.setSupportActionBar(this)
@@ -25,14 +26,26 @@ fun MaterialToolbar.setupHeader1(activity: AppCompatActivity, titleResId: Int) {
         icon = ContextCompat.getDrawable(context, R.drawable.ic_settings)
         setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
     }
+    menu.findItem(R.id.action_logout)?.apply {
+        icon = ContextCompat.getDrawable(context, R.drawable.ic_logout)
+        setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
+    }
 
     // 클릭 리스너
     this.setOnMenuItemClickListener { item ->
-        if (item.itemId == R.id.action_settings) {
-            activity.startActivity(Intent(activity, SettingsActivity::class.java))
-            true
-        } else {
-            false
+        when (item.itemId) {
+            R.id.action_settings -> {
+                activity.startActivity(Intent(activity, SettingsActivity::class.java))
+                true
+            }
+            R.id.action_logout -> {
+                com.pnu.pnuguide.data.AuthRepository.signOut()
+                val intent = Intent(activity, LoginActivity::class.java)
+                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                activity.startActivity(intent)
+                true
+            }
+            else -> false
         }
     }
 }
@@ -53,14 +66,26 @@ fun MaterialToolbar.setupHeader1(activity: AppCompatActivity, title: String) {
         icon = ContextCompat.getDrawable(context, R.drawable.ic_settings)
         setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
     }
+    menu.findItem(R.id.action_logout)?.apply {
+        icon = ContextCompat.getDrawable(context, R.drawable.ic_logout)
+        setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS)
+    }
 
     // 클릭 리스너
     this.setOnMenuItemClickListener { item ->
-        if (item.itemId == R.id.action_settings) {
-            activity.startActivity(Intent(activity, SettingsActivity::class.java))
-            true
-        } else {
-            false
+        when (item.itemId) {
+            R.id.action_settings -> {
+                activity.startActivity(Intent(activity, SettingsActivity::class.java))
+                true
+            }
+            R.id.action_logout -> {
+                com.pnu.pnuguide.data.AuthRepository.signOut()
+                val intent = Intent(activity, LoginActivity::class.java)
+                intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                activity.startActivity(intent)
+                true
+            }
+            else -> false
         }
     }
 }

--- a/app/src/main/res/layout/item_message_bot.xml
+++ b/app/src/main/res/layout/item_message_bot.xml
@@ -2,7 +2,9 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:gravity="start">
+    android:gravity="start"
+    android:layout_marginTop="4dp"
+    android:layout_marginBottom="4dp">
 
     <TextView
         android:id="@+id/text_message"

--- a/app/src/main/res/layout/item_message_user.xml
+++ b/app/src/main/res/layout/item_message_user.xml
@@ -2,7 +2,9 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:gravity="end">
+    android:gravity="end"
+    android:layout_marginTop="4dp"
+    android:layout_marginBottom="4dp">
 
     <TextView
         android:id="@+id/text_message"


### PR DESCRIPTION
## Summary
- handle logout action in toolbar helper so activities using `setupHeader1` correctly log out
- add vertical margins to chat message layouts for better spacing

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858702b83308332830cafac1f0d5dce