### PR TITLE
Add App Info screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -57,6 +57,7 @@
         <activity android:name="com.pnu.pnuguide.ui.quiz.QuizActivity" />
         <activity android:name="com.pnu.pnuguide.ui.profile.EditProfileActivity" />
         <activity android:name="com.pnu.pnuguide.ui.SettingsActivity" />
+        <activity android:name="com.pnu.pnuguide.ui.AppInfoActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/pnu/pnuguide/ui/AppInfoActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/AppInfoActivity.kt
@@ -1,0 +1,28 @@
+package com.pnu.pnuguide.ui
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.appbar.MaterialToolbar
+import com.pnu.pnuguide.BuildConfig
+import com.pnu.pnuguide.R
+
+class AppInfoActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_app_info)
+
+        val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_app_info)
+        toolbar.setupHeader2(this, R.string.app_info)
+
+        val versionView = findViewById<TextView>(R.id.tv_app_version)
+        versionView.text = "Version: ${BuildConfig.VERSION_NAME}"
+
+        findViewById<TextView>(R.id.tv_readme_link).setOnClickListener {
+            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.readme_url)))
+            startActivity(intent)
+        }
+    }
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/SettingsActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/SettingsActivity.kt
@@ -5,6 +5,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.appbar.MaterialToolbar
 import com.pnu.pnuguide.R
 import com.pnu.pnuguide.ui.setupHeader2
+import com.pnu.pnuguide.ui.AppInfoActivity
 import android.widget.TextView
 import android.widget.ImageView
 import com.google.firebase.auth.FirebaseAuth
@@ -29,6 +30,10 @@ class SettingsActivity : AppCompatActivity() {
 
         setItem(R.id.item_account, R.drawable.ic_profile, "Account Settings")
         setItem(R.id.item_info, android.R.drawable.ic_menu_info_details, "App Information")
+
+        findViewById<android.view.View>(R.id.item_info).setOnClickListener {
+            startActivity(android.content.Intent(this, AppInfoActivity::class.java))
+        }
     }
 
     private fun setItem(resId: Int, iconRes: Int, title: String) {

--- a/app/src/main/res/layout/activity_app_info.xml
+++ b/app/src/main/res/layout/activity_app_info.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@color/background_light"
+    android:padding="16dp">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar_app_info"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/background_light"
+        android:navigationIcon="@drawable/ic_arrow_back_black_24"
+        android:title="@string/app_info"
+        android:titleTextColor="@color/text_primary"
+        app:titleCentered="true" />
+
+    <TextView
+        android:id="@+id/tv_app_version"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:textColor="@color/text_primary"
+        android:textSize="16sp" />
+
+    <TextView
+        android:id="@+id/tv_readme_link"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="@string/readme_url"
+        android:textColor="@color/primary"
+        android:textSize="16sp" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,4 +44,6 @@
     <string name="send">Send</string>
     <string name="hint_message">Type a message</string>
     <string name="stamp_label_detected">인식된 스팟: %1$s</string>
+    <string name="app_info">App Info</string>
+    <string name="readme_url">https://github.com/SonJH7/PNUGuide/blob/main/README.md</string>
 </resources>


### PR DESCRIPTION
## Summary
- add `AppInfoActivity` with README link
- display the new screen from settings

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858911d20408332acda6b17cacdcf8b