### PR TITLE
Enable editing email from settings

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/data/UserRepository.kt
+++ b/app/src/main/java/com/pnu/pnuguide/data/UserRepository.kt
@@ -1,0 +1,27 @@
+package com.pnu.pnuguide.data
+
+import com.google.android.gms.tasks.Task
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.SetOptions
+import com.google.firebase.firestore.ktx.firestoreSettings
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+object UserRepository {
+    private val firestore = FirebaseFirestore.getInstance().apply {
+        firestoreSettings = firestoreSettings { isPersistenceEnabled = true }
+    }
+
+    suspend fun updateEmail(uid: String, email: String) {
+        firestore.collection("users")
+            .document(uid)
+            .set(mapOf("email" to email), SetOptions.merge())
+            .await()
+    }
+}
+
+private suspend fun <T> Task<T>.await(): T = suspendCancellableCoroutine { cont ->
+    addOnSuccessListener { cont.resume(it) }
+    addOnFailureListener { cont.resumeWithException(it) }
+}

--- a/app/src/main/java/com/pnu/pnuguide/ui/HomeFragment.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/HomeFragment.kt
@@ -58,6 +58,15 @@ class HomeFragment : Fragment() {
         progressBar.progress = count
     }
 
+    override fun onResume() {
+        super.onResume()
+        view?.let { v ->
+            val user = FirebaseAuth.getInstance().currentUser
+            val prefix = user?.email?.substringBefore("@") ?: ""
+            v.findViewById<TextView>(R.id.tv_welcome)?.text = "방문을 환영합니다! ${prefix}님"
+        }
+    }
+
     private fun openCampusMapPdf() {
         val inputStream = resources.openRawResource(R.raw.campus_map)
         val file = File(requireContext().getExternalFilesDir(null), "campus_map.pdf")

--- a/app/src/main/java/com/pnu/pnuguide/ui/SettingsActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/SettingsActivity.kt
@@ -1,15 +1,24 @@
 package com.pnu.pnuguide.ui
 
 import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.EditText
+import android.widget.ImageView
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.appbar.MaterialToolbar
+import com.google.firebase.auth.FirebaseAuth
 import com.pnu.pnuguide.R
+import com.pnu.pnuguide.data.UserRepository
 import com.pnu.pnuguide.ui.setupHeader2
 import com.pnu.pnuguide.ui.AppInfoActivity
-import android.widget.TextView
-import android.widget.ImageView
-import com.google.firebase.auth.FirebaseAuth
-
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.launch
 
 class SettingsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -19,26 +28,77 @@ class SettingsActivity : AppCompatActivity() {
         val toolbar = findViewById<MaterialToolbar>(R.id.toolbar_settings)
         toolbar.setupHeader2(this, R.string.settings)
 
-        val user = FirebaseAuth.getInstance().currentUser
         val nameView = findViewById<TextView>(R.id.tv_settings_name)
         val emailView = findViewById<TextView>(R.id.tv_settings_email)
-        val email = user?.email
-        val prefix = email?.substringBefore("@") ?: ""
-        nameView.text = prefix
-        emailView.text = email ?: ""
+        updateUserInfo(nameView, emailView)
 
-
-        setItem(R.id.item_account, R.drawable.ic_profile, "Account Settings")
+        setItem(R.id.item_account, R.drawable.ic_profile, getString(R.string.edit_profile))
         setItem(R.id.item_info, android.R.drawable.ic_menu_info_details, "App Information")
 
-        findViewById<android.view.View>(R.id.item_info).setOnClickListener {
+        findViewById<View>(R.id.item_info).setOnClickListener {
             startActivity(android.content.Intent(this, AppInfoActivity::class.java))
+        }
+
+        findViewById<View>(R.id.item_account).setOnClickListener {
+            val user = FirebaseAuth.getInstance().currentUser
+            val email = user?.email ?: ""
+            showEditEmailDialog(email) { newEmail ->
+                val uid = user?.uid
+                if (uid != null) {
+                    CoroutineScope(Dispatchers.IO).launch {
+                        try {
+                            user.updateEmail(newEmail).await()
+                            UserRepository.updateEmail(uid, newEmail)
+                            runOnUiThread {
+                                updateUserInfo(nameView, emailView)
+                                Toast.makeText(this@SettingsActivity, "Email updated", Toast.LENGTH_SHORT).show()
+                            }
+                        } catch (e: Exception) {
+                            runOnUiThread {
+                                Toast.makeText(this@SettingsActivity, e.message, Toast.LENGTH_SHORT).show()
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 
+    private fun updateUserInfo(nameView: TextView, emailView: TextView) {
+        val email = FirebaseAuth.getInstance().currentUser?.email
+        val prefix = email?.substringBefore("@") ?: ""
+        nameView.text = prefix
+        emailView.text = email ?: ""
+    }
+
     private fun setItem(resId: Int, iconRes: Int, title: String) {
-        val view = findViewById<android.view.View>(resId)
+        val view = findViewById<View>(resId)
         view.findViewById<ImageView>(R.id.icon).setImageResource(iconRes)
         view.findViewById<TextView>(R.id.title).text = title
     }
+
+    private fun showEditEmailDialog(currentEmail: String, onUpdate: (String) -> Unit) {
+        val dialogView = LayoutInflater.from(this).inflate(R.layout.dialog_edit_email, null)
+        val edit = dialogView.findViewById<EditText>(R.id.edit_email)
+        edit.setText(currentEmail)
+        val dialog = AlertDialog.Builder(this)
+            .setView(dialogView)
+            .create()
+        dialogView.findViewById<View>(R.id.button_close).setOnClickListener { dialog.dismiss() }
+        dialogView.findViewById<View>(R.id.button_update).setOnClickListener {
+            val newEmail = edit.text.toString().trim()
+            if (newEmail.isNotEmpty() && newEmail != currentEmail) {
+                dialog.dismiss()
+                onUpdate(newEmail)
+            } else {
+                Toast.makeText(this, "Enter a new email", Toast.LENGTH_SHORT).show()
+            }
+        }
+        dialog.show()
+    }
+}
+
+private suspend fun <T> com.google.android.gms.tasks.Task<T>.await(): T = kotlinx.coroutines.suspendCancellableCoroutine { cont ->
+    addOnSuccessListener { cont.resume(it) }
+    addOnFailureListener { cont.resumeWithException(it) }
 }

--- a/app/src/main/res/layout/dialog_edit_email.xml
+++ b/app/src/main/res/layout/dialog_edit_email.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <EditText
+        android:id="@+id/edit_email"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="textEmailAddress"
+        android:hint="@string/new_email" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="end"
+        android:paddingTop="16dp">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/button_update"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/update" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/button_close"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/close"
+            android:layout_marginStart="8dp" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,9 @@
     <string name="settings">Settings</string>
     <string name="logout">Log out</string>
     <string name="edit_profile">Edit Profile</string>
+    <string name="new_email">New Email</string>
+    <string name="update">Update</string>
+    <string name="close">Close</string>
     <string name="pnu_guide">PNU Guide</string>
     <string name="pnu_guide_update">PNU Guide Update</string>
     <string name="title_course">Course</string>


### PR DESCRIPTION
## Summary
- add dialog layout to edit email
- create simple `UserRepository` for user info updates
- hook up a profile editing action in `SettingsActivity`
- refresh welcome message on HomeFragment resume
- add translations for edit email dialog

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858929cc80c8332b34680e97fccb79b