### PR TITLE
Fix resume() usage for Kotlin coroutines

### DIFF
--- a/app/src/main/java/com/pnu/pnuguide/data/AuthRepository.kt
+++ b/app/src/main/java/com/pnu/pnuguide/data/AuthRepository.kt
@@ -46,6 +46,6 @@ object AuthRepository {
 }
 
 private suspend fun <T> Task<T>.await(): T = suspendCancellableCoroutine { cont ->
-    addOnSuccessListener { cont.resume(it) }
+    addOnSuccessListener { cont.resume(it) {} }
     addOnFailureListener { cont.resumeWithException(it) }
 }

--- a/app/src/main/java/com/pnu/pnuguide/data/ChatRepository.kt
+++ b/app/src/main/java/com/pnu/pnuguide/data/ChatRepository.kt
@@ -46,6 +46,6 @@ object ChatRepository {
 }
 
 private suspend fun <T> Task<T>.await(): T = suspendCancellableCoroutine { cont ->
-    addOnSuccessListener { cont.resume(it) }
+    addOnSuccessListener { cont.resume(it) {} }
     addOnFailureListener { cont.resumeWithException(it) }
 }

--- a/app/src/main/java/com/pnu/pnuguide/data/StampRepository.kt
+++ b/app/src/main/java/com/pnu/pnuguide/data/StampRepository.kt
@@ -24,6 +24,6 @@ object StampRepository {
 }
 
 private suspend fun <T> Task<T>.await(): T = suspendCancellableCoroutine { cont ->
-    addOnSuccessListener { cont.resume(it) }
+    addOnSuccessListener { cont.resume(it) {} }
     addOnFailureListener { cont.resumeWithException(it) }
 }

--- a/app/src/main/java/com/pnu/pnuguide/data/UserRepository.kt
+++ b/app/src/main/java/com/pnu/pnuguide/data/UserRepository.kt
@@ -22,6 +22,6 @@ object UserRepository {
 }
 
 private suspend fun <T> Task<T>.await(): T = suspendCancellableCoroutine { cont ->
-    addOnSuccessListener { cont.resume(it) }
+    addOnSuccessListener { cont.resume(it) {} }
     addOnFailureListener { cont.resumeWithException(it) }
 }

--- a/app/src/main/java/com/pnu/pnuguide/ui/SettingsActivity.kt
+++ b/app/src/main/java/com/pnu/pnuguide/ui/SettingsActivity.kt
@@ -98,7 +98,8 @@ class SettingsActivity : AppCompatActivity() {
     }
 }
 
-private suspend fun <T> com.google.android.gms.tasks.Task<T>.await(): T = kotlinx.coroutines.suspendCancellableCoroutine { cont ->
-    addOnSuccessListener { cont.resume(it) }
-    addOnFailureListener { cont.resumeWithException(it) }
-}
+private suspend fun <T> com.google.android.gms.tasks.Task<T>.await(): T =
+    kotlinx.coroutines.suspendCancellableCoroutine { cont ->
+        addOnSuccessListener { cont.resume(it) {} }
+        addOnFailureListener { cont.resumeWithException(it) }
+    }


### PR DESCRIPTION
## Summary
- update Task.await extension functions for new `resume` API

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685894da3e9c8332bec9643ef73af3a0